### PR TITLE
Remote debug support: Support attaching to a specific UNIX domain socket.

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,10 @@
 								"type": "boolean",
 								"description": "Show a log of DAP requests, events, and responses",
 								"default": false
+							},
+							"sockPath": {
+								"type": "string",
+								"description": "(Optional) Location of the UNIX domain socket to attach to"
 							}
 						}
 					},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,6 +201,9 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 	}
 
 	async get_sock_list(config: AttachConfiguration): Promise<string[]> {
+		if (config.sockPath) {
+			return [config.sockPath];
+		}
 		const rdbg = config.rdbgPath || "rdbg";
 		const exec = util.promisify(require('child_process').exec);
 		const cmd = this.make_shell_command(rdbg + ' --util=list-socks');
@@ -422,6 +425,7 @@ interface AttachConfiguration extends DebugConfiguration {
 	type: 'rdbg';
 	request: 'attach';
 	rdbgPath?: string;
+	sockPath?: string;
 	showProtocolLog?: boolean;
 }
 


### PR DESCRIPTION
Remote debug support: Support attaching to a specific UNIX domain socket. Adds a `sockPath` option to attach configuration. (I am OK with other names; I noticed `rdbg` had a `--sock-path` option and thought I should use the same name.)

**Context**

Stripe's development environment sets up a UNIX domain socket at a specific file path for debugging a Ruby process on a remote machine. This setting will allow us to experiment with using rdbg for debugging (although we will need to work around https://github.com/ruby/debug/issues/463 before it will work :) ).