### PR TITLE
ignore node_modules

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -9,3 +9,4 @@ vsc-extension-quickstart.md
 **/.eslintrc.json
 **/*.map
 **/*.ts
+node_modules


### PR DESCRIPTION
I do not believe any `npm` packages are being used within the extension. extension.ts only imports from vscode and node.
I am currently building my own version slightly different, but my `.vsix` bundle was ~1.3MB. I removed `node_modules` and it went down to ~10KB.