### PR TITLE
Multiple remote -> local mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ You can use the following "launch" configurations.
   * Note that you can specify `0` TCP/IP port (choose usable port) with debug.gem v1.5.0 or later.
 * `waitLaunchTime`: If you want to open TCP/IP debug port, you may need to wait for opening debug port. On default, it waits 1000 milli seconds (1 sec) but if it is not enough, please specify more wait time (default: `1000` in milli seconds). With debug.gem 1.5.0 and later you may not need this configulation.
 * `localfs`: On TCP/IP, if target host is local machine, set `true` and you can open the file directly (default: `false`).
+* `sourceMappings`: An array of remote to local directory mappings
+  * `remoteRoot`: Absolute path to the remote directory containing the program.
+  * `localRoot`: Absolute path to the local directory (default: `${workspaceFolder}`)
 
 Note that if you have a trouble by launching `rdbg`, please try to specify `rdbgPath`. Without this configuration, this extension simply calls `rdbg` in PATH.
 

--- a/package.json
+++ b/package.json
@@ -63,10 +63,20 @@
 							},
 							"sourceMappings": {
 								"type": "array",
-								"description": "Absolute path to the remote directory containing the program",
+								"description": "Map remote directories to local ones",
 								"items": {
-									"remoteRoot": "string",
-									"localRootp": "string"
+									"type": "object",
+									"properties": {
+										"remoteRoot": {
+											"type": "string",
+											"description": "Absolute path to the remote directory containing the program"
+										},
+										"localRoot": {
+											"type": "string",
+											"description": "Absolute path to the local directory containing the program",
+											"default": "${workspaceFolder}"
+										}
+									}
 								}
 							},
 							"showProtocolLog": {

--- a/package.json
+++ b/package.json
@@ -61,9 +61,13 @@
 								"type": "string",
 								"description": "UNIX domain socket name or TPC/IP host:port"
 							},
-							"remoteRoot": {
-								"type": "string",
-								"description": "Absolute path to the remote directory containing the program"
+							"sourceMappings": {
+								"type": "array",
+								"description": "Absolute path to the remote directory containing the program",
+								"items": {
+									"remoteRoot": "string",
+									"localRootp": "string"
+								}
 							},
 							"showProtocolLog": {
 								"type": "boolean",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
 								"type": "string",
 								"description": "UNIX domain socket name or TPC/IP host:port"
 							},
+							"remoteRoot": {
+								"type": "string",
+								"description": "Absolute path to the remote directory containing the program"
+							},
 							"showProtocolLog": {
 								"type": "boolean",
 								"description": "Show a log of DAP requests, events, and responses",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,11 +178,12 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
       }
     };
     tracker.onWillReceiveMessage = (message: any): void => {
-      if (message.command === 'setBreakpoints') {
-        mapArgumentSourceFiles(message)
-      } else if (message.command === 'source') {
-        mapArgumentSourceFiles(message)
-      }
+			switch (message.command) {
+				case 'setBreakpoints':
+				case 'source':
+          mapArgumentSourceFiles(message)
+					break
+			}
       if (session.configuration.showProtocolLog) {
         outputChannel.appendLine("[VSCode->DA] " + JSON.stringify(message));
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,27 +167,27 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 				}
 			}
 		}
-    tracker.onDidSendMessage = (message: any): void => {
-      if (message.command === 'stackTrace') {
-        if (message.body?.stackFrames && session.workspaceFolder) {
+		tracker.onDidSendMessage = (message: any): void => {
+			if (message.command === 'stackTrace') {
+				if (message.body?.stackFrames && session.workspaceFolder) {
 					mapStackFramesSourceFiles(message)
-        }
-      }
-      if (session.configuration.showProtocolLog) {
-        outputChannel.appendLine("[DA->VSCode] " + JSON.stringify(message));
-      }
-    };
-    tracker.onWillReceiveMessage = (message: any): void => {
+				}
+			}
+			if (session.configuration.showProtocolLog) {
+				outputChannel.appendLine("[DA->VSCode] " + JSON.stringify(message));
+			}
+		};
+		tracker.onWillReceiveMessage = (message: any): void => {
 			switch (message.command) {
 				case 'setBreakpoints':
 				case 'source':
-          mapArgumentSourceFiles(message)
+					mapArgumentSourceFiles(message)
 					break
 			}
-      if (session.configuration.showProtocolLog) {
-        outputChannel.appendLine("[VSCode->DA] " + JSON.stringify(message));
-      }
-    };
+			if (session.configuration.showProtocolLog) {
+				outputChannel.appendLine("[VSCode->DA] " + JSON.stringify(message));
+			}
+		};
 		return tracker;
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -644,13 +644,18 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 	}
 }
 
+interface SourceMapping {
+	remoteRoot: string;
+	localRoot?: string;
+}
+
 interface AttachConfiguration extends DebugConfiguration {
 	type: 'rdbg';
 	request: 'attach';
 	rdbgPath?: string;
 	debugPort?: string;
 	cwd?: string;
-  remoteWorkspaceRoot?: string,
+	sourceMappings?: [SourceMapping],
 	showProtocolLog?: boolean;
 
 	autoAttach?: string;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -195,6 +195,9 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvider {
 	resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
 		if (config.script || config.request == 'attach') {
+			if (config.sourceMappings) {
+				config.localfs = true
+			}
 			return config;
 		}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 				}
 			},
 			onError(e) {
-				outputChannel.appendLine("[Error on seession]\n" + e.name + ": " + e.message + "\ne: " + JSON.stringify(e));
+				outputChannel.appendLine("[Error on session]\n" + e.name + ": " + e.message + "\ne: " + JSON.stringify(e));
 			}
 		};
     tracker.onDidSendMessage = (message: any): void => {


### PR DESCRIPTION
This is still a work in progress, I have only used it sparingly in a branch to ensure basic functionality. I am just wondering if this is something you are interested in merging.

[`sourceMappings`](https://github.com/firien/vscode-rdbg/blob/fdad2d2a85ba0b7f56e94234684811cedb5ab9d6/package.json#L64) allows multiple remote directories to be mapped to local directories. As mentioned in [#29](https://github.com/ruby/vscode-rdbg/issues/29#issuecomment-1101530565), I have a dockerized rails app; vscode `workspaceFolder` is mapped to a docker volume. But I also have a ruby gems docker volume that is handled by docker that I am more or less oblivious of. With `sourceMappings` I can set breakpoints and traverse call stack through both app code & gems.

```jsonc
{
  "type": "rdbg",
  "name": "Attach with rdbg",
  "request": "attach",
  "debugPort": "12345",
  "sourceMappings": [
    {
      "remoteRoot": "/rails_app" //this is dockerized rails app
      // with localRoot missing - it defaults to workspaceFolder
    },
    {
      "remoteRoot": "/usr/local/bundle", //ruby gems in docker
      "localRoot": "/home/user/.local/share/docker/volumes/app_gems/_data" //local mapping of ruby gem docker volume
    },
  ]
}
```

If `sourceMappings` is set, then `localfs` is automatically set to `true`. In the example above, this has the side effect of loading gem files that should probably remain read-only as editable, but I can live with that for now.

----

I am not thrilled with any configuration option names: sourceMappings, remoteRoot, localRoot can all be renamed.

----

Related Issues

* #14
* #29
* #32