### PR TITLE
Wait 30 seconds for socket instead of 3

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -445,7 +445,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		let i = 0;
 		while (!fs.existsSync(path)) {
 			i++;
-			if (i > 30) {
+			if (i > 300) {
 				vscode.window.showErrorMessage("Couldn't start debug session (wait for " + (Date.now() - start_time) + " ms). Please install debug.gem.");
 				return false;
 			}


### PR DESCRIPTION
Ideally this setting would be configurable but currently 3 seconds isn't enough
for certain use cases, e.g. when rdbg is called with bundle exec in a project
with a giant Gemfile.