### PR TITLE
Support breakpoints in haml and slim files as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,12 @@
 		"breakpoints": [
 			{
 				"language": "ruby"
+			},
+			{
+				"language": "haml"
+			},
+			{
+				"language": "slim"
 			}
 		],
 		"debuggers": [


### PR DESCRIPTION
Closes #54

This addresses an issue I ran into when trying to debug rails projects which use haml or slim. With this change vscode properly allows me to set breakpoints in those files as well.