### PR TITLE
Pass tests on CI for macOS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Install Node.js
       uses: actions/setup-node@v3
       with:
@@ -31,5 +30,18 @@ jobs:
     - run: npm install
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'
+    # VS code overrides The PATH environment variable:
+    # https://github.com/microsoft/vscode/blob/1.73.0/src/vs/server/node/extensionHostConnection.ts#L59
+    # Thus, when we execute ruby command like `ruby target.rb`, the `ruby` path may be wrong as follows
+    # 
+    # The PATH environment variable before running VS Code:
+    #   /Users/runner/work/vscode-rdbg/vscode-rdbg/node_modules/.bin:/Users/runner/work/vscode-rdbg/node_modules/ ... /bin:/Users/runner/hostedtoolcache/Ruby/3.1.2/ ...
+    # 
+    # The PATH environment variable after running VS Code:
+    #   /usr/local/lib/ruby/gems/3.0.0/bin:/usr/local/opt/ruby@3.0/ ... /Users/runner/work/vscode-rdbg/vscode-rdbg/node_modules/.bin:/Users/runner/work/vscode-rdbg/node_modules/
+    # 
+    # The RUBY_DEBUG_TEST_PATH environment variable is for setting correct ruby path when testing.
+    - run: echo "RUBY_DEBUG_TEST_PATH=`which ruby`" >> $GITHUB_ENV
+      if: runner.os == 'macOS'
     - run: npm test
       if: runner.os != 'Linux'

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -4,6 +4,7 @@ import * as assert from 'assert';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 
+import * as child_process from 'child_process';
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -278,12 +279,16 @@ function generateAttachConfig(): AttachConfiguration {
 }
 
 function generateLaunchConfig(script: string): LaunchConfiguration {
-	return {
+	const config: LaunchConfiguration = {
 		type: 'rdbg',
 		name: '',
 		request: 'launch',
 		script,
 	};
+	if (process.platform === 'darwin' && process.env.RUBY_DEBUG_TEST_PATH) {
+		config.command = process.env.RUBY_DEBUG_TEST_PATH;
+	}
+	return config;
 }
 
 interface AttachConfiguration extends vscode.DebugConfiguration {


### PR DESCRIPTION
VS code overrides The PATH environment variable:
https://github.com/microsoft/vscode/blob/1.73.0/src/vs/server/node/extensionHostConnection.ts#L59
Thus, when we execute ruby command like `ruby target.rb`, the `ruby` path may be wrong as follows

The PATH environment variable before running VS Code:
  /Users/runner/work/vscode-rdbg/vscode-rdbg/node_modules/.bin:/Users/runner/work/vscode-rdbg/node_modules/ ... /bin:/Users/runner/hostedtoolcache/Ruby/3.1.2/ ...

The PATH environment variable after running VS Code:
  /usr/local/lib/ruby/gems/3.0.0/bin:/usr/local/opt/ruby@3.0/ ... /Users/runner/work/vscode-rdbg/vscode-rdbg/node_modules/.bin:/Users/runner/work/vscode-rdbg/node_modules/

To solve this problem, I set The RUBY_DEBUG_TEST_PATH environment variable for getting correct ruby path when testing.