### PR TITLE
Remove unused vscode-test package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,7 @@
 				"eslint": "^7.9.0",
 				"glob": "^8.0.3",
 				"mocha": "^10.1.0",
-				"typescript": "^4.0.2",
-				"vscode-test": "^1.4.0"
+				"typescript": "^4.0.2"
 			},
 			"engines": {
 				"vscode": "^1.49.0"
@@ -2534,22 +2533,6 @@
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
 		},
-		"node_modules/vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-			"dev": true,
-			"dependencies": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			},
-			"engines": {
-				"node": ">=8.9.3"
-			}
-		},
 		"node_modules/which": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4531,18 +4514,6 @@
 			"resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
 			"integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
 			"dev": true
-		},
-		"vscode-test": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-			"integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-			"dev": true,
-			"requires": {
-				"http-proxy-agent": "^4.0.1",
-				"https-proxy-agent": "^5.0.0",
-				"rimraf": "^3.0.2",
-				"unzipper": "^0.10.11"
-			}
 		},
 		"which": {
 			"version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -214,7 +214,6 @@
 		"eslint": "^7.9.0",
 		"glob": "^8.0.3",
 		"mocha": "^10.1.0",
-		"typescript": "^4.0.2",
-		"vscode-test": "^1.4.0"
+		"typescript": "^4.0.2"
 	}
 }


### PR DESCRIPTION
Because vscode-test pakcage has been renamed to @vscode/test-electron and we use @vscode/test-electron, we can remove vscode-test package