### PR TITLE
Wait 5 seconds instead of 1 second when launching debugger on windows

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -596,7 +596,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 					}
 				}
 				else {
-					const wait_ms = config.waitLaunchTime ? config.waitLaunchTime : 1000 /* 1 sec */;
+					const wait_ms = config.waitLaunchTime ? config.waitLaunchTime : 5000 /* 5 sec */;
 					await this.sleep_ms(wait_ms);
 				}
 


### PR DESCRIPTION
Related to #58

The reason of connection failure is that extension tries to connect even though the debuggee has not been started yet