### PR TITLE
Run the debuggee process in spawn method for performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,6 +151,11 @@
 								"type": "boolean",
 								"description": "true if the VSCode and debugger run on a same machine",
 								"default": false
+							},
+							"useTerminal": {
+								"type": "boolean",
+								"description": "Create a new terminal and then execute commands there",
+								"default": false
 							}
 						}
 					}


### PR DESCRIPTION
Currently, debugging the Ruby program in `lauch` type is slow. This PR make it faster. The following table is a measurement in my environment(MacBook Pro (16-inch, 2021), Apple M1 Max).

<!DOCTYPE html>

  | 1st | 2nd | 3rd | 4th | 5th
-- | -- | -- | -- | -- | --
PR change(ms) | 1106.6303749084473 | 1089.6812920570374 |  1069.392292022705 | 1002.0327911376953 | 1022.7554998397827
Current implementation(ms) | 5010.751667022705 | 4919.522166252136 | 4946.293709278107 | 5031.6767501831055 | 4882.8968334198

## Target Script

```ruby
a=1
b=2
c=3
d=4
```

## JSON file

```json
{
    // Use IntelliSense to learn about possible attributes.
    // Hover to view descriptions of existing attributes.
    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
    "version": "0.2.0",
    "configurations": [
        {
            "type": "rdbg",
            "name": "Debug current file with rdbg",
            "request": "launch",
            "script": "${file}",
            "args": [],
            "waitLaunchTime": 40000,
            "debugPort": "0",
        }
    ]
}
```
