### PR TITLE
Activate Ruby environment using version managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,20 @@ In this case, the current directory of host (`${workspaceFolder}`) is shared wit
         }
 ```
 
+### Selecting a version manager
+
+In order to launch the debugger using the correct Ruby version, rdbg allows configuring your preferred version manager, which is used to activate the Ruby environment.
+
+```jsonc
+// Default value is "none" for not using a version manager to activate the environment
+// Available managers are shadowenv, chruby, asdf, rbenv and rvm
+
+{
+  // User settings
+  "rdbg.rubyVersionManager": "none"
+}
+```
+
 ## Acknowledgement
 
 * This extension is based on [Ethan Reesor / VSCode Byebug · GitLab](https://gitlab.com/firelizzard/vscode-byebug/-/tree/master/) by Ethan Reesor. Without his great work, the extension can not be released (Koichi learned TypeScript, VSCode extension and DAP by his extension).

--- a/package.json
+++ b/package.json
@@ -208,6 +208,18 @@
 					"//": "The default value will be changed to true after 1.8.0 is released",
 					"default": false,
 					"description": "(experimental) Enable RdbgTraceInspector view. RdbgTraceInspector visualizes the trace log in Tree View. This feature will work in the version of debug.gem is 1.8.0 or higher."
+				},
+				"rdbg.rubyVersionManager": {
+					"type": "string",
+					"enum": [
+						"shadowenv",
+						"chruby",
+						"asdf",
+						"rbenv",
+						"rvm",
+						"none"
+					],
+					"default": "none"
 				}
 			}
 		},


### PR DESCRIPTION
Closes #21

Add Ruby environment activation through version managers. This PR
- Exposes a new configuration to select a version manager
- Implements how to activate the Ruby environment based on each manager
- Starts activating the environment before trying to run the `rdbg` executable