### PR TITLE
Wait 20 seconds for each test case

### DIFF
--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -9,7 +9,7 @@ export function run(): Promise<void> {
 		color: true
 	});
 
-	mocha.timeout('10000');
+	mocha.timeout('20000');
 
 	const testsRoot = path.resolve(__dirname, '..');
 


### PR DESCRIPTION
This PR fixes https://github.com/ruby/vscode-rdbg/actions/runs/4228707945/jobs/7352553458#step:9:95.

The reason for timeout error is debugger always wait 10 seconds here https://github.com/ruby/vscode-rdbg/blob/master/src/test/suite/extension.test.ts#L387 on windows. Thus, we need to change the timeout in mocha.