### PR TITLE
Improve ESLint rules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -71,6 +71,10 @@
                 "caughtErrorsIgnorePattern": "^_"
             }
         ],
-        "eqeqeq": "warn"
+        "eqeqeq": "warn",
+        "quotes": [
+            "warn",
+            "double"
+        ]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,6 +62,14 @@
         "object-curly-spacing": [
             "warn",
             "always"
+        ],
+        "no-unused-vars": [
+            "warn",
+            {
+                "argsIgnorePattern": "^_",
+                "varsIgnorePattern": "^_",
+                "caughtErrorsIgnorePattern": "^_"
+            }
         ]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,17 +9,59 @@
         "@typescript-eslint"
     ],
     "rules": {
-        "@typescript-eslint/naming-convention": ["warn", {
-            "format": ["camelCase", "snake_case"],
-            "selector": ["variableLike"],
-            "leadingUnderscore": "allow"
-        }],
+        "@typescript-eslint/naming-convention": [
+            "warn",
+            {
+                "selector": "default",
+                "format": [
+                    "camelCase",
+                    "PascalCase",
+                    "UPPER_CASE"
+                ],
+                "leadingUnderscore": "allow",
+                "trailingUnderscore": "allow"
+            },
+            {
+                "selector": "typeLike",
+                "format": [
+                    "PascalCase"
+                ]
+            },
+            {
+                "selector": "typeParameter",
+                "format": [
+                    "PascalCase"
+                ],
+                "prefix": [
+                    "T"
+                ]
+            },
+            {
+                "selector": "interface",
+                "format": [
+                    "PascalCase"
+                ],
+                "custom": {
+                    "regex": "^I[A-Z]",
+                    "match": false
+                }
+            }
+        ],
         "@typescript-eslint/semi": "warn",
         "@typescript-eslint/type-annotation-spacing": "warn",
         "no-unused-expressions": "error",
         "no-throw-literal": "warn",
         "semi": "off",
-        "indent": ["warn", "tab", { "SwitchCase": 1 }],
-        "object-curly-spacing": ["warn", "always"]
+        "indent": [
+            "warn",
+            "tab",
+            {
+                "SwitchCase": 1
+            }
+        ],
+        "object-curly-spacing": [
+            "warn",
+            "always"
+        ]
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -75,6 +75,7 @@
         "quotes": [
             "warn",
             "double"
-        ]
+        ],
+        "prefer-const": "warn"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -70,6 +70,7 @@
                 "varsIgnorePattern": "^_",
                 "caughtErrorsIgnorePattern": "^_"
             }
-        ]
+        ],
+        "eqeqeq": "warn"
     }
 }

--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
 		"vscode:prepublish": "npm run compile",
 		"compile": "tsc -p ./",
 		"lint": "eslint src --ext ts",
+		"format": "eslint src --ext ts --fix",
 		"watch": "tsc -watch -p ./",
 		"pretest": "npm run compile && npm run lint",
 		"test": "node ./out/test/runTest.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -53,7 +53,7 @@ function pp(obj: any) {
 	outputChannel.appendLine(JSON.stringify(obj));
 }
 
-function exportBreakpoints(context: vscode.ExtensionContext) {
+function exportBreakpoints() {
 	if (vscode.workspace.getConfiguration("rdbg").get("saveBreakpoints")) {
 		let wspath = workspaceFolder();
 
@@ -68,7 +68,7 @@ function exportBreakpoints(context: vscode.ExtensionContext) {
 				}
 			}
 			const bpPath = path.join(wspath, ".rdbgrc.breakpoints");
-			fs.writeFile(bpPath, bpLines, e => { });
+			fs.writeFile(bpPath, bpLines, () => { });
 			outputChannel.appendLine("Written: " + bpPath);
 		}
 	}
@@ -82,8 +82,8 @@ export function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory('rdbg', new RdbgDebugAdapterTrackerFactory()));
 
 	//
-	context.subscriptions.push(vscode.debug.onDidChangeBreakpoints(e => {
-		exportBreakpoints(context);
+	context.subscriptions.push(vscode.debug.onDidChangeBreakpoints(() => {
+		exportBreakpoints();
 	}));
 
 	context.subscriptions.push(vscode.debug.onDidStartDebugSession(async session => {
@@ -162,7 +162,7 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 }
 
 class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvider {
-	resolveDebugConfiguration(folder: WorkspaceFolder | undefined, config: DebugConfiguration, token?: CancellationToken): ProviderResult<DebugConfiguration> {
+	resolveDebugConfiguration(_folder: WorkspaceFolder | undefined, config: DebugConfiguration, _token?: CancellationToken): ProviderResult<DebugConfiguration> {
 		if (config.script || config.request == 'attach') {
 			return config;
 		}
@@ -187,7 +187,7 @@ class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvi
 		};
 	};
 
-	provideDebugConfigurations(folder: WorkspaceFolder | undefined): ProviderResult<DebugConfiguration[]> {
+	provideDebugConfigurations(_folder: WorkspaceFolder | undefined): ProviderResult<DebugConfiguration[]> {
 		return [
 			{
 				type: 'rdbg',
@@ -210,7 +210,7 @@ class StopDebugAdapter implements vscode.DebugAdapter {
 	private sendMessage = new vscode.EventEmitter<any>();
 	readonly onDidSendMessage: vscode.Event<any> = this.sendMessage.event;
 
-	handleMessage(message: any): void {
+	handleMessage(): void {
 		const ev = {
 			type: 'event',
 			seq: 1,
@@ -236,7 +236,7 @@ const findRDBGTerminal = (): vscode.Terminal | undefined => {
 };
 
 class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
-	createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable | undefined): Promise<DebugAdapterDescriptor> {
+	createDebugAdapterDescriptor(session: DebugSession, _executable: DebugAdapterExecutable | undefined): Promise<DebugAdapterDescriptor> {
 		// session.configuration.internalConsoleOptions = "neverOpen"; // TODO: doesn't affect...
 		const c = session.configuration;
 
@@ -415,10 +415,10 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 			});
 			let path: string;
 
-			p.on('error', e => {
+			p.on('error', () => {
 				resolve(undefined);
 			});
-			p.on('exit', (code) => {
+			p.on('exit', () => {
 				resolve(path);
 			});
 			p.stderr?.on('data', err => {
@@ -493,7 +493,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 	}
 
 	async sleepMs(waitMs: number) {
-		await new Promise((resolve, reject) => {
+		await new Promise((resolve, _reject) => {
 			setTimeout(() => {
 				resolve(0);
 			}, waitMs); // ms

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,7 +21,7 @@ import {
 import { DebugProtocol } from "@vscode/debugprotocol";
 
 let outputChannel: vscode.OutputChannel;
-let outputTerminals = new Map<string, vscode.Terminal>();
+const outputTerminals = new Map<string, vscode.Terminal>();
 let lastExecCommand: string | undefined;
 let lastProgram: string | undefined;
 
@@ -55,7 +55,7 @@ function pp(obj: any) {
 
 function exportBreakpoints() {
 	if (vscode.workspace.getConfiguration("rdbg").get("saveBreakpoints")) {
-		let wspath = workspaceFolder();
+		const wspath = workspaceFolder();
 
 		if (wspath) {
 			var bpLines = "";
@@ -139,7 +139,7 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 				outputChannel.appendLine("[Start session]\n" + JSON.stringify(session));
 			},
 			onWillStopSession(): void {
-				let outputTerminal = outputTerminals.get(session.id);
+				const outputTerminal = outputTerminals.get(session.id);
 				if (outputTerminal) {
 					outputTerminal.show();
 					outputTerminals.delete(session.id);
@@ -225,7 +225,7 @@ class StopDebugAdapter implements vscode.DebugAdapter {
 
 const findRDBGTerminal = (): vscode.Terminal | undefined => {
 	let terminal: vscode.Terminal | undefined;
-	let currentTerminals: vscode.Terminal[] = Array.from(outputTerminals.values());
+	const currentTerminals: vscode.Terminal[] = Array.from(outputTerminals.values());
 	for (const t of vscode.window.terminals) {
 		if (t.name === terminalName && !t.exitStatus && !currentTerminals.includes(t)) {
 			terminal = t;
@@ -297,7 +297,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 				if (err || stderr) {
 					reject(err ?? stderr);
 				} else {
-					let socks: Array<string> = [];
+					const socks: Array<string> = [];
 					if (stdout.length > 0) {
 						for (const line of stdout.split("\n")) {
 							if (line.length > 0) {
@@ -656,7 +656,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		const useBundlerFlag = (config.useBundler !== undefined) ? config.useBundler : vscode.workspace.getConfiguration("rdbg").get("useBundler");
 		const useBundler = useBundlerFlag && fs.existsSync(workspaceFolder() + "/Gemfile");
 		const rubyCommand = config.command ? config.command : (useBundler ? "bundle exec ruby" : "ruby");
-		let execArgs = config.script + " " + (config.args ? config.args.join(" ") : "");
+		const execArgs = config.script + " " + (config.args ? config.args.join(" ") : "");
 		let execCommand: string | undefined = rubyCommand + " " + execArgs;
 
 		if (config.askParameters) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,10 +104,10 @@ export function activate(context: vscode.ExtensionContext) {
 
 	const folders = vscode.workspace.workspaceFolders;
 
-	if (folders != undefined && folders.length > 0) {
+	if (folders !== undefined && folders.length > 0) {
 		const autoAttachConfigP = (c: AttachConfiguration): boolean => {
-			if (c.type == "rdbg" && c.request == "attach" && c.autoAttach) {
-				if (c.autoAttach == process.env.RUBY_DEBUG_AUTOATTACH) {
+			if (c.type === "rdbg" && c.request === "attach" && c.autoAttach) {
+				if (c.autoAttach === process.env.RUBY_DEBUG_AUTOATTACH) {
 					return true;
 				}
 
@@ -163,7 +163,7 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 
 class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvider {
 	resolveDebugConfiguration(_folder: WorkspaceFolder | undefined, config: DebugConfiguration, _token?: CancellationToken): ProviderResult<DebugConfiguration> {
-		if (config.script || config.request == 'attach') {
+		if (config.script || config.request === 'attach') {
 			return config;
 		}
 
@@ -173,7 +173,7 @@ class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvi
 			});
 
 		// launch without configuration
-		if (vscode.window.activeTextEditor?.document.languageId != 'ruby')
+		if (vscode.window.activeTextEditor?.document.languageId !== 'ruby')
 			return vscode.window.showInformationMessage("Select a ruby file to debug").then(_ => {
 				return null;
 			});
@@ -240,7 +240,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		// session.configuration.internalConsoleOptions = "neverOpen"; // TODO: doesn't affect...
 		const c = session.configuration;
 
-		if (c.request == 'attach') {
+		if (c.request === 'attach') {
 			return this.attach(session);
 		}
 		else {
@@ -388,7 +388,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 				resolve(undefined);
 			});
 			p.on('exit', (code) => {
-				if (code != 0) {
+				if (code !== 0) {
 					this.showError("exit code is " + code);
 					resolve(undefined);
 				}
@@ -445,7 +445,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 				resolve(null);
 			});
 			p.on('exit', (code) => {
-				if (code != 0) {
+				if (code !== 0) {
 					this.showError(command + ": exit code is " + code);
 					resolve(null);
 				}
@@ -546,7 +546,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 
 			if (process.platform === 'win32' && tcpPort === 0) {
 				tcpPort = this.getRandomPort();
-			} else if (tcpPort != undefined) {
+			} else if (tcpPort !== undefined) {
 				tcpPortFile = await this.getTcpPortFile(config);
 			}
 		} else if (process.platform === 'win32') {
@@ -631,7 +631,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 				return new DebugAdapterInlineImplementation(new StopDebugAdapter);
 			}
 		}
-		else if (tcpPort != undefined) {
+		else if (tcpPort !== undefined) {
 			if (tcpPortFile) {
 				if (await this.waitFile(tcpPortFile, config.waitLaunchTime)) {
 					const portStr = fs.readFileSync(tcpPortFile);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,8 @@
-import * as child_process from 'child_process';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as net from 'net';
-import * as vscode from 'vscode';
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as path from "path";
+import * as net from "net";
+import * as vscode from "vscode";
 
 import {
 	CancellationToken,
@@ -16,16 +16,16 @@ import {
 	ProviderResult,
 	WorkspaceFolder,
 	ThemeIcon
-} from 'vscode';
+} from "vscode";
 
-import { DebugProtocol } from '@vscode/debugprotocol';
+import { DebugProtocol } from "@vscode/debugprotocol";
 
 let outputChannel: vscode.OutputChannel;
 let outputTerminals = new Map<string, vscode.Terminal>();
 let lastExecCommand: string | undefined;
 let lastProgram: string | undefined;
 
-const terminalName: string = 'Ruby Debug Terminal';
+const terminalName: string = "Ruby Debug Terminal";
 
 function workspaceFolder(): string | undefined {
 	if (vscode.workspace.workspaceFolders) {
@@ -75,11 +75,11 @@ function exportBreakpoints() {
 }
 
 export function activate(context: vscode.ExtensionContext) {
-	outputChannel = vscode.window.createOutputChannel('rdbg');
+	outputChannel = vscode.window.createOutputChannel("rdbg");
 
-	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider('rdbg', new RdbgInitialConfigurationProvider()));
-	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory('rdbg', new RdbgAdapterDescriptorFactory()));
-	context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory('rdbg', new RdbgDebugAdapterTrackerFactory()));
+	context.subscriptions.push(vscode.debug.registerDebugConfigurationProvider("rdbg", new RdbgInitialConfigurationProvider()));
+	context.subscriptions.push(vscode.debug.registerDebugAdapterDescriptorFactory("rdbg", new RdbgAdapterDescriptorFactory()));
+	context.subscriptions.push(vscode.debug.registerDebugAdapterTrackerFactory("rdbg", new RdbgDebugAdapterTrackerFactory()));
 
 	//
 	context.subscriptions.push(vscode.debug.onDidChangeBreakpoints(() => {
@@ -88,14 +88,14 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.debug.onDidStartDebugSession(async session => {
 		const config = session.configuration;
-		if (config.request !== 'launch' || config.useTerminal || config.noDebug) return;
+		if (config.request !== "launch" || config.useTerminal || config.noDebug) return;
 
 		const args: DebugProtocol.EvaluateArguments = {
-			expression: ',eval $stdout.sync=true',
-			context: 'repl'
+			expression: ",eval $stdout.sync=true",
+			context: "repl"
 		};
 		try {
-			await session.customRequest('evaluate', args);
+			await session.customRequest("evaluate", args);
 		} catch (err) {
 			// We need to ignore the error because this request will be failed if the version of rdbg is older than 1.7. The `,command` API is introduced from version 1.7.
 			pp(err);
@@ -118,7 +118,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 		const jsonPath = path.join(folders[0].uri.fsPath, ".vscode/rdbg_autoattach.json");
 		if (fs.existsSync(jsonPath)) {
-			const c: AttachConfiguration = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+			const c: AttachConfiguration = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
 
 			if (autoAttachConfigP(c)) {
 				fs.unlinkSync(jsonPath);
@@ -163,7 +163,7 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 
 class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvider {
 	resolveDebugConfiguration(_folder: WorkspaceFolder | undefined, config: DebugConfiguration, _token?: CancellationToken): ProviderResult<DebugConfiguration> {
-		if (config.script || config.request === 'attach') {
+		if (config.script || config.request === "attach") {
 			return config;
 		}
 
@@ -173,16 +173,16 @@ class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvi
 			});
 
 		// launch without configuration
-		if (vscode.window.activeTextEditor?.document.languageId !== 'ruby')
+		if (vscode.window.activeTextEditor?.document.languageId !== "ruby")
 			return vscode.window.showInformationMessage("Select a ruby file to debug").then(_ => {
 				return null;
 			});
 
 		return {
-			type: 'rdbg',
-			name: 'Launch',
-			request: 'launch',
-			script: '${file}',
+			type: "rdbg",
+			name: "Launch",
+			request: "launch",
+			script: "${file}",
 			askParameters: true,
 		};
 	};
@@ -190,17 +190,17 @@ class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvi
 	provideDebugConfigurations(_folder: WorkspaceFolder | undefined): ProviderResult<DebugConfiguration[]> {
 		return [
 			{
-				type: 'rdbg',
-				name: 'Debug current file with rdbg',
-				request: 'launch',
-				script: '${file}',
+				type: "rdbg",
+				name: "Debug current file with rdbg",
+				request: "launch",
+				script: "${file}",
 				args: [],
 				askParameters: true,
 			},
 			{
-				type: 'rdbg',
-				name: 'Attach with rdbg',
-				request: 'attach',
+				type: "rdbg",
+				name: "Attach with rdbg",
+				request: "attach",
 			}
 		];
 	};
@@ -212,9 +212,9 @@ class StopDebugAdapter implements vscode.DebugAdapter {
 
 	handleMessage(): void {
 		const ev = {
-			type: 'event',
+			type: "event",
 			seq: 1,
-			event: 'terminated',
+			event: "terminated",
 		};
 		this.sendMessage.fire(ev);
 	}
@@ -240,7 +240,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		// session.configuration.internalConsoleOptions = "neverOpen"; // TODO: doesn't affect...
 		const c = session.configuration;
 
-		if (c.request === 'attach') {
+		if (c.request === "attach") {
 			return this.attach(session);
 		}
 		else {
@@ -288,7 +288,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 
 	async getSockList(config: AttachConfiguration): Promise<string[]> {
 		const rdbg = config.rdbgPath || "rdbg";
-		const cmd = this.makeShellCommand(rdbg + ' --util=list-socks');
+		const cmd = this.makeShellCommand(rdbg + " --util=list-socks");
 		return new Promise((resolve, reject) => {
 			child_process.exec(cmd, {
 				cwd: config.cwd ? customPath(config.cwd) : workspaceFolder(),
@@ -383,11 +383,11 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 			});
 			let path: string;
 
-			p.on('error', e => {
+			p.on("error", e => {
 				this.showError(e.message);
 				resolve(undefined);
 			});
-			p.on('exit', (code) => {
+			p.on("exit", (code) => {
 				if (code !== 0) {
 					this.showError("exit code is " + code);
 					resolve(undefined);
@@ -396,10 +396,10 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 					resolve(path);
 				}
 			});
-			p.stderr?.on('data', err => {
+			p.stderr?.on("data", err => {
 				outputChannel.appendLine(err);
 			});
-			p.stdout?.on('data', out => {
+			p.stdout?.on("data", out => {
 				path = out.trim();
 			});
 		});
@@ -415,16 +415,16 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 			});
 			let path: string;
 
-			p.on('error', () => {
+			p.on("error", () => {
 				resolve(undefined);
 			});
-			p.on('exit', () => {
+			p.on("exit", () => {
 				resolve(path);
 			});
-			p.stderr?.on('data', err => {
+			p.stderr?.on("data", err => {
 				outputChannel.appendLine(err);
 			});
-			p.stdout?.on('data', out => {
+			p.stdout?.on("data", out => {
 				path = out.trim();
 			});
 		});
@@ -440,11 +440,11 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 			});
 			let version: string;
 
-			p.on('error', e => {
+			p.on("error", e => {
 				this.showError(e.message);
 				resolve(null);
 			});
-			p.on('exit', (code) => {
+			p.on("exit", (code) => {
 				if (code !== 0) {
 					this.showError(command + ": exit code is " + code);
 					resolve(null);
@@ -453,10 +453,10 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 					resolve(version);
 				}
 			});
-			p.stderr?.on('data', err => {
+			p.stderr?.on("data", err => {
 				outputChannel.appendLine(err);
 			});
-			p.stdout?.on('data', out => {
+			p.stdout?.on("data", out => {
 				version = out.trim();
 			});
 		});
@@ -476,9 +476,9 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 	envPrefix(env?: { [key: string]: string }): string {
 		if (env) {
 			let prefix = "";
-			if (process.platform === 'win32') {
+			if (process.platform === "win32") {
 				for (const key in env) {
-					prefix += '$Env:' + key + "='" + env[key] + "'; ";
+					prefix += "$Env:" + key + "='" + env[key] + "'; ";
 				}
 			} else {
 				for (const key in env) {
@@ -544,12 +544,12 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		if (config.debugPort) {
 			[tcpHost, tcpPort, sockPath] = this.parsePort(config.debugPort);
 
-			if (process.platform === 'win32' && tcpPort === 0) {
+			if (process.platform === "win32" && tcpPort === 0) {
 				tcpPort = this.getRandomPort();
 			} else if (tcpPort !== undefined) {
 				tcpPortFile = await this.getTcpPortFile(config);
 			}
-		} else if (process.platform === 'win32') {
+		} else if (process.platform === "win32") {
 			// default
 			tcpHost = "localhost";
 			tcpPort = this.getRandomPort();
@@ -570,7 +570,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 
 		if (!outputTerminal) {
 			const shell = process.env.SHELL;
-			const shellArgs = this.supportLogin(shell) ? ['-l'] : undefined;
+			const shellArgs = this.supportLogin(shell) ? ["-l"] : undefined;
 
 			outputTerminal = vscode.window.createTerminal({
 				name: terminalName,
@@ -582,7 +582,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		}
 		outputTerminals.set(session.id, outputTerminal);
 
-		let execCommand = '';
+		let execCommand = "";
 		try {
 			execCommand = await this.getExecCommands(config);
 		} catch (error) {
@@ -603,7 +603,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 			} else {
 				rdbgArgs = this.getUnixRdbgArgs(execCommand, sockPath);
 			}
-			cmdline += rdbg + ' ' + rdbgArgs.join(' ');
+			cmdline += rdbg + " " + rdbgArgs.join(" ");
 		}
 
 		if (outputTerminal) {
@@ -654,10 +654,10 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 
 	async getExecCommands(config: LaunchConfiguration) {
 		const useBundlerFlag = (config.useBundler !== undefined) ? config.useBundler : vscode.workspace.getConfiguration("rdbg").get("useBundler");
-		const useBundler = useBundlerFlag && fs.existsSync(workspaceFolder() + '/Gemfile');
-		const rubyCommand = config.command ? config.command : (useBundler ? 'bundle exec ruby' : 'ruby');
-		let execArgs = config.script + " " + (config.args ? config.args.join(' ') : '');
-		let execCommand: string | undefined = rubyCommand + ' ' + execArgs;
+		const useBundler = useBundlerFlag && fs.existsSync(workspaceFolder() + "/Gemfile");
+		const rubyCommand = config.command ? config.command : (useBundler ? "bundle exec ruby" : "ruby");
+		let execArgs = config.script + " " + (config.args ? config.args.join(" ") : "");
+		let execCommand: string | undefined = rubyCommand + " " + execArgs;
 
 		if (config.askParameters) {
 			if (lastExecCommand && lastProgram === config.script) {
@@ -681,26 +681,26 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 
 	getTCPRdbgArgs(execCommand: string, host: string, port: number, portPath?: string) {
 		const rdbgArgs: string[] = [];
-		rdbgArgs.push('--command', '--open', '--stop-at-load');
+		rdbgArgs.push("--command", "--open", "--stop-at-load");
 		rdbgArgs.push("--host=" + host);
 		let portArg = port.toString();
 		if (portPath) {
 			portArg += ":" + portPath;
 		}
 		rdbgArgs.push("--port=" + portArg);
-		rdbgArgs.push('--');
-		rdbgArgs.push(...execCommand.trim().split(' '));
+		rdbgArgs.push("--");
+		rdbgArgs.push(...execCommand.trim().split(" "));
 		return rdbgArgs;
 	}
 
 	getUnixRdbgArgs(execCommand: string, sockPath?: string) {
 		const rdbgArgs: string[] = [];
-		rdbgArgs.push('--command', '--open', '--stop-at-load');
+		rdbgArgs.push("--command", "--open", "--stop-at-load");
 		if (sockPath) {
 			rdbgArgs.push("--sock-path=" + sockPath);
 		}
-		rdbgArgs.push('--');
-		rdbgArgs.push(...execCommand.trim().split(' '));
+		rdbgArgs.push("--");
+		rdbgArgs.push(...execCommand.trim().split(" "));
 		return rdbgArgs;
 	}
 
@@ -711,7 +711,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 
 		// outputChannel.appendLine(JSON.stringify(session));
 
-		let execCommand = '';
+		let execCommand = "";
 		try {
 			execCommand = await this.getExecCommands(config);
 		} catch (error) {
@@ -722,9 +722,9 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		}
 		const options: child_process.SpawnOptionsWithoutStdio = {
 			env: { ...process.env, ...config.env },
-			cwd: customPath(config.cwd || ''),
+			cwd: customPath(config.cwd || ""),
 		};
-		if (process.platform === 'win32') options.shell = 'powershell';
+		if (process.platform === "win32") options.shell = "powershell";
 
 		let sockPath: string | undefined = undefined;
 		let tcpHost: string | undefined = undefined;
@@ -733,7 +733,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 		if (config.debugPort) {
 			[tcpHost, tcpPort, sockPath] = this.parsePort(config.debugPort);
 		}
-		else if (process.platform === 'win32') {
+		else if (process.platform === "win32") {
 			// default
 			tcpHost = "localhost";
 			tcpPort = 0;
@@ -774,19 +774,19 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 	};
 
 	private runDebuggeeWithUnix(debugConsole: vscode.DebugConsole, cmd: string, args?: string[] | undefined, options?: child_process.SpawnOptionsWithoutStdio) {
-		pp(`Running: ${cmd} ${args?.join(' ')}`);
+		pp(`Running: ${cmd} ${args?.join(" ")}`);
 		let connectionReady = false;
-		let sockPath = '';
-		let stderr = '';
+		let sockPath = "";
+		let stderr = "";
 		return new Promise<string>((resolve, reject) => {
 			const debugProcess = child_process.spawn(cmd, args, options);
-			debugProcess.stderr.on('data', (chunk) => {
+			debugProcess.stderr.on("data", (chunk) => {
 				const msg: string = chunk.toString();
 				stderr += msg;
-				if (stderr.includes('Error')) {
+				if (stderr.includes("Error")) {
 					reject(new Error(stderr));
 				}
-				if (stderr.includes('DEBUGGER: wait for debugger connection...')) {
+				if (stderr.includes("DEBUGGER: wait for debugger connection...")) {
 					connectionReady = true;
 				}
 				const found = stderr.match(this.unixDomainRegex);
@@ -799,14 +799,14 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 					resolve(sockPath);
 				}
 			});
-			debugProcess.stdout.on('data', (chunk) => {
+			debugProcess.stdout.on("data", (chunk) => {
 				debugConsole.append(this.colorMessage(chunk.toString(), this.colors.blue));
 			});
-			debugProcess.on('error', (err) => {
+			debugProcess.on("error", (err) => {
 				debugConsole.append(err.message);
 				reject(err);
 			});
-			debugProcess.on('exit', (code) => {
+			debugProcess.on("exit", (code) => {
 				reject(new Error(`Couldn't start debug session. The debuggee process exited with code ${code}`));
 			});
 		});
@@ -815,20 +815,20 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 	private readonly TCPRegex = /DEBUGGER:\sDebugger\scan\sattach\svia\s.+\((.+):(\d+)\)/;
 
 	private runDebuggeeWithTCP(debugConsole: vscode.DebugConsole, cmd: string, args?: string[] | undefined, options?: child_process.SpawnOptionsWithoutStdio) {
-		pp(`Running: ${cmd} ${args?.join(' ')}`);
+		pp(`Running: ${cmd} ${args?.join(" ")}`);
 		let connectionReady = false;
-		let host = '';
+		let host = "";
 		let port = -1;
-		let stderr = '';
+		let stderr = "";
 		return new Promise<[string, number]>((resolve, reject) => {
 			const debugProcess = child_process.spawn(cmd, args, options);
-			debugProcess.stderr.on('data', (chunk) => {
+			debugProcess.stderr.on("data", (chunk) => {
 				const msg: string = chunk.toString();
 				stderr += msg;
-				if (stderr.includes('Error')) {
+				if (stderr.includes("Error")) {
 					reject(new Error(stderr));
 				}
-				if (stderr.includes('DEBUGGER: wait for debugger connection...')) {
+				if (stderr.includes("DEBUGGER: wait for debugger connection...")) {
 					connectionReady = true;
 				}
 				const found = stderr.match(this.TCPRegex);
@@ -842,14 +842,14 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 					resolve([host, port]);
 				}
 			});
-			debugProcess.stdout.on('data', (chunk) => {
+			debugProcess.stdout.on("data", (chunk) => {
 				debugConsole.append(this.colorMessage(chunk.toString(), this.colors.blue));
 			});
-			debugProcess.on('error', (err) => {
+			debugProcess.on("error", (err) => {
 				debugConsole.append(err.message);
 				reject(err);
 			});
-			debugProcess.on('exit', (code) => {
+			debugProcess.on("exit", (code) => {
 				reject(new Error(`Couldn't start debug session. The debuggee process exited with code ${code}`));
 			});
 		});
@@ -859,8 +859,8 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
 class InvalidExecCommandError extends Error { }
 
 interface AttachConfiguration extends DebugConfiguration {
-	type: 'rdbg';
-	request: 'attach';
+	type: "rdbg";
+	request: "attach";
 	rdbgPath?: string;
 	env?: { [key: string]: string };
 	debugPort?: string;
@@ -871,8 +871,8 @@ interface AttachConfiguration extends DebugConfiguration {
 }
 
 interface LaunchConfiguration extends DebugConfiguration {
-	type: 'rdbg';
-	request: 'launch';
+	type: "rdbg";
+	request: "launch";
 
 	script: string;
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,21 +1,21 @@
-import * as path from 'path';
+import * as path from "path";
 
-import { runTests } from '@vscode/test-electron';
+import { runTests } from "@vscode/test-electron";
 
 async function main() {
 	try {
 		// The folder containing the Extension Manifest package.json
 		// Passed to `--extensionDevelopmentPath`
-		const extensionDevelopmentPath = path.resolve(__dirname, '../../');
+		const extensionDevelopmentPath = path.resolve(__dirname, "../../");
 
 		// The path to test runner
 		// Passed to --extensionTestsPath
-		const extensionTestsPath = path.resolve(__dirname, './suite/index');
+		const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
 		// Download VS Code, unzip it and run the integration test
 		await runTests({ extensionDevelopmentPath, extensionTestsPath });
 	} catch (err) {
-		console.error('Failed to run tests');
+		console.error("Failed to run tests");
 		process.exit(1);
 	}
 }

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -4,13 +4,11 @@ import * as assert from 'assert';
 // as well as import your extension to test it
 import * as vscode from 'vscode';
 
-import * as child_process from 'child_process';
 import * as net from 'net';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { DebugProtocol } from '@vscode/debugprotocol';
-import * as myExtension from '../../extension';
 
 const twoCrlf = '\r\n\r\n';
 
@@ -93,7 +91,7 @@ suite('attach', () => {
 		let server: net.Server;
 		setup(() => {
 			server = net.createServer((sock) => {
-				sock.on('data', (data: Buffer) => {
+				sock.on('data', (_data: Buffer) => {
 					sock.end();
 				});
 			});
@@ -180,7 +178,7 @@ suite('attach', () => {
 			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-rdbg-test-'));
 			sockPath = tempDir + '/' + Date.now().toString() + '.sock';
 			server = net.createServer((sock) => {
-				sock.on('data', (data: Buffer) => {
+				sock.on('data', (_data: Buffer) => {
 					sock.end();
 				});
 			});
@@ -216,7 +214,7 @@ suite('launch', () => {
 		let port: number;
 		setup(() => {
 			const server = net.createServer((sock) => {
-				sock.on('data', (data: Buffer) => {
+				sock.on('data', (_data: Buffer) => {
 					sock.end();
 				});
 			});
@@ -280,7 +278,7 @@ suite('launch', () => {
 		let port: number;
 		setup(() => {
 			const server = net.createServer((sock) => {
-				sock.on('data', (data: Buffer) => {
+				sock.on('data', (_data: Buffer) => {
 					sock.end();
 				});
 			});

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,29 +1,29 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
-import * as vscode from 'vscode';
+import * as vscode from "vscode";
 
-import * as net from 'net';
-import * as fs from 'fs';
-import * as path from 'path';
-import * as os from 'os';
-import { DebugProtocol } from '@vscode/debugprotocol';
+import * as net from "net";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { DebugProtocol } from "@vscode/debugprotocol";
 
-const twoCrlf = '\r\n\r\n';
+const twoCrlf = "\r\n\r\n";
 
-suite('attach', () => {
-	suite('tcp: success', () => {
+suite("attach", () => {
+	suite("tcp: success", () => {
 		let server: net.Server;
 		setup(() => {
 			server = net.createServer((sock) => {
-				sock.on('data', (data: Buffer) => {
+				sock.on("data", (data: Buffer) => {
 					const rawReq = data.toString().split(twoCrlf);
 					try {
 						const req = JSON.parse(rawReq[1]) as DebugProtocol.Request;
 						const res: DebugProtocol.Response = {
 							seq: req.seq,
-							type: 'response',
+							type: "response",
 							// eslint-disable-next-line @typescript-eslint/naming-convention
 							request_seq: req.seq,
 							success: true,
@@ -39,7 +39,7 @@ suite('attach', () => {
 				});
 			});
 			server.listen(0, () => {
-				console.log('server bound');
+				console.log("server bound");
 			});
 		});
 
@@ -47,7 +47,7 @@ suite('attach', () => {
 			server.close();
 		});
 
-		test('localhost:{port}', async () => {
+		test("localhost:{port}", async () => {
 			const addr = server.address() as net.AddressInfo;
 			const port = addr.port;
 			const c = generateAttachConfig();
@@ -56,7 +56,7 @@ suite('attach', () => {
 			assert.ok(success);
 		});
 
-		test('port', async () => {
+		test("port", async () => {
 			const addr = server.address() as net.AddressInfo;
 			const port = addr.port;
 			const c = generateAttachConfig();
@@ -65,7 +65,7 @@ suite('attach', () => {
 			assert.ok(success);
 		});
 
-		suite('auto attach', () => {
+		suite("auto attach", () => {
 			const key = Math.random().toString();
 			suiteSetup(() => {
 				process.env.RUBY_DEBUG_AUTOATTACH = key;
@@ -75,7 +75,7 @@ suite('attach', () => {
 				process.env.RUBY_DEBUG_AUTOATTACH = undefined;
 			});
 
-			test('success', async () => {
+			test("success", async () => {
 				const addr = server.address() as net.AddressInfo;
 				const port = addr.port;
 				const c = generateAttachConfig();
@@ -87,16 +87,16 @@ suite('attach', () => {
 		});
 	});
 
-	suite('tcp: fail', () => {
+	suite("tcp: fail", () => {
 		let server: net.Server;
 		setup(() => {
 			server = net.createServer((sock) => {
-				sock.on('data', (_data: Buffer) => {
+				sock.on("data", (_data: Buffer) => {
 					sock.end();
 				});
 			});
 			server.listen(0, () => {
-				console.log('server bound');
+				console.log("server bound");
 			});
 		});
 
@@ -104,7 +104,7 @@ suite('attach', () => {
 			server.close();
 		});
 
-		test('return false', async () => {
+		test("return false", async () => {
 			const addr = server.address() as net.AddressInfo;
 			const port = addr.port;
 			const c = generateAttachConfig();
@@ -114,23 +114,23 @@ suite('attach', () => {
 		});
 	});
 
-	suite('unix domain socket: success', () => {
+	suite("unix domain socket: success", () => {
 		let server: net.Server | undefined;
 		let tempDir: string | undefined;
 		let sockPath: string | undefined;
 		setup(function () {
-			if (process.platform === 'win32') this.skip();
+			if (process.platform === "win32") this.skip();
 
-			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-rdbg-test-'));
-			sockPath = tempDir + '/' + Date.now().toString() + '.sock';
+			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vscode-rdbg-test-"));
+			sockPath = tempDir + "/" + Date.now().toString() + ".sock";
 			server = net.createServer((sock) => {
-				sock.on('data', (data: Buffer) => {
+				sock.on("data", (data: Buffer) => {
 					const rawReq = data.toString().split(twoCrlf);
 					try {
 						const req = JSON.parse(rawReq[1]) as DebugProtocol.Request;
 						const res: DebugProtocol.Response = {
 							seq: req.seq,
-							type: 'response',
+							type: "response",
 							// eslint-disable-next-line @typescript-eslint/naming-convention
 							request_seq: req.seq,
 							success: true,
@@ -146,7 +146,7 @@ suite('attach', () => {
 				});
 			});
 			server.listen(sockPath, () => {
-				console.log('server bound');
+				console.log("server bound");
 			});
 		});
 
@@ -155,7 +155,7 @@ suite('attach', () => {
 			if (tempDir) fs.rmdirSync(tempDir);
 		});
 
-		test('return true', async () => {
+		test("return true", async () => {
 			return new Promise((resolve, reject) => {
 				if (server === undefined || sockPath === undefined) return reject();
 				const c = generateAttachConfig();
@@ -168,22 +168,22 @@ suite('attach', () => {
 		});
 	});
 
-	suite('unix domain socket: fail', () => {
+	suite("unix domain socket: fail", () => {
 		let server: net.Server | undefined;
 		let tempDir: string | undefined;
 		let sockPath: string | undefined;
 		setup(function () {
-			if (process.platform === 'win32') this.skip();
+			if (process.platform === "win32") this.skip();
 
-			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-rdbg-test-'));
-			sockPath = tempDir + '/' + Date.now().toString() + '.sock';
+			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vscode-rdbg-test-"));
+			sockPath = tempDir + "/" + Date.now().toString() + ".sock";
 			server = net.createServer((sock) => {
-				sock.on('data', (_data: Buffer) => {
+				sock.on("data", (_data: Buffer) => {
 					sock.end();
 				});
 			});
 			server.listen(sockPath, () => {
-				console.log('server bound');
+				console.log("server bound");
 			});
 		});
 
@@ -192,7 +192,7 @@ suite('attach', () => {
 			if (tempDir) fs.rmdirSync(tempDir);
 		});
 
-		test('return false', async () => {
+		test("return false", async () => {
 			return new Promise((resolve, reject) => {
 				if (server === undefined || sockPath === undefined) return reject();
 				const c = generateAttachConfig();
@@ -206,41 +206,41 @@ suite('attach', () => {
 	});
 });
 
-suite('launch', () => {
-	suite('tcp: success', () => {
-		const projectRoot = path.join(__dirname, '..', '..', '..');
-		const testData = path.join(projectRoot, 'src', 'test', 'testdata', 'test.rb');
+suite("launch", () => {
+	suite("tcp: success", () => {
+		const projectRoot = path.join(__dirname, "..", "..", "..");
+		const testData = path.join(projectRoot, "src", "test", "testdata", "test.rb");
 
 		let port: number;
 		setup(() => {
 			const server = net.createServer((sock) => {
-				sock.on('data', (_data: Buffer) => {
+				sock.on("data", (_data: Buffer) => {
 					sock.end();
 				});
 			});
 			server.listen(0, () => {
-				console.log('server bound');
+				console.log("server bound");
 			});
 			const addr = server.address() as net.AddressInfo;
 			port = addr.port;
 			server.close();
 		});
 
-		test('localhost:{port}', async () => {
+		test("localhost:{port}", async () => {
 			const c = generateLaunchConfig(testData);
 			c.debugPort = `localhost:${port}`;
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 
-		test('port', async () => {
+		test("port", async () => {
 			const c = generateLaunchConfig(testData);
 			c.debugPort = port.toString();
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 
-		test('env', async () => {
+		test("env", async () => {
 			const c = generateLaunchConfig(testData);
 			c.env = { "SAMPLE": "sample" };
 			c.debugPort = port.toString();
@@ -248,21 +248,21 @@ suite('launch', () => {
 			assert.ok(success);
 		});
 
-		test('v2: localhost:{port}', async () => {
+		test("v2: localhost:{port}", async () => {
 			const c = generateLaunchV2Config(testData);
 			c.debugPort = `localhost:${port}`;
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 
-		test('v2: port', async () => {
+		test("v2: port", async () => {
 			const c = generateLaunchV2Config(testData);
 			c.debugPort = port.toString();
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 
-		test('v2: env', async () => {
+		test("v2: env", async () => {
 			const c = generateLaunchV2Config(testData);
 			c.env = { "SAMPLE": "sample" };
 			c.debugPort = port.toString();
@@ -271,26 +271,26 @@ suite('launch', () => {
 		});
 	});
 
-	suite('tcp: fail', () => {
-		const projectRoot = path.join(__dirname, '..', '..', '..');
-		const testData = path.join(projectRoot, 'src', 'test', 'testdata', 'test.rb');
+	suite("tcp: fail", () => {
+		const projectRoot = path.join(__dirname, "..", "..", "..");
+		const testData = path.join(projectRoot, "src", "test", "testdata", "test.rb");
 
 		let port: number;
 		setup(() => {
 			const server = net.createServer((sock) => {
-				sock.on('data', (_data: Buffer) => {
+				sock.on("data", (_data: Buffer) => {
 					sock.end();
 				});
 			});
 			server.listen(0, () => {
-				console.log('server bound');
+				console.log("server bound");
 			});
 			const addr = server.address() as net.AddressInfo;
 			port = addr.port;
 			server.close();
 		});
 
-		test('noDebug is true', async () => {
+		test("noDebug is true", async () => {
 			const c = generateLaunchConfig(testData);
 			c.debugPort = port.toString();
 			c.noDebug = true;
@@ -298,7 +298,7 @@ suite('launch', () => {
 			assert.ok(!success);
 		});
 
-		test('v2: noDebug is true', async () => {
+		test("v2: noDebug is true", async () => {
 			const c = generateLaunchV2Config(testData);
 			c.debugPort = port.toString();
 			c.noDebug = true;
@@ -307,33 +307,33 @@ suite('launch', () => {
 		});
 	});
 
-	suite('default: success', () => {
-		const projectRoot = path.join(__dirname, '..', '..', '..');
-		const testData = path.join(projectRoot, 'src', 'test', 'testdata', 'test.rb');
+	suite("default: success", () => {
+		const projectRoot = path.join(__dirname, "..", "..", "..");
+		const testData = path.join(projectRoot, "src", "test", "testdata", "test.rb");
 
-		test('config.debugPort is undefined', async () => {
+		test("config.debugPort is undefined", async () => {
 			const c = generateLaunchConfig(testData);
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 
-		test('v2: config.debugPort is undefined', async () => {
+		test("v2: config.debugPort is undefined", async () => {
 			const c = generateLaunchV2Config(testData);
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 	});
 
-	suite('unix domain socket: fail', () => {
-		const projectRoot = path.join(__dirname, '..', '..', '..');
-		const testData = path.join(projectRoot, 'src', 'test', 'testdata', 'test.rb');
+	suite("unix domain socket: fail", () => {
+		const projectRoot = path.join(__dirname, "..", "..", "..");
+		const testData = path.join(projectRoot, "src", "test", "testdata", "test.rb");
 		let tempDir: string | undefined;
 		let sockPath: string | undefined;
 		setup(function () {
-			if (process.platform === 'win32') this.skip();
+			if (process.platform === "win32") this.skip();
 
-			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vscode-rdbg-test-'));
-			sockPath = tempDir + '/' + Date.now().toString() + '.sock';
+			tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "vscode-rdbg-test-"));
+			sockPath = tempDir + "/" + Date.now().toString() + ".sock";
 		});
 
 		teardown(async () => {
@@ -341,14 +341,14 @@ suite('launch', () => {
 			if (tempDir) fs.rmdirSync(tempDir);
 		});
 
-		test('return false', async () => {
+		test("return false", async () => {
 			const c = generateLaunchConfig(testData);
 			c.debugPort = sockPath;
 			const success = await vscode.debug.startDebugging(undefined, c);
 			assert.ok(success);
 		});
 
-		test('v2: return false', async () => {
+		test("v2: return false", async () => {
 			const c = generateLaunchV2Config(testData);
 			c.debugPort = sockPath;
 			const success = await vscode.debug.startDebugging(undefined, c);
@@ -371,22 +371,22 @@ async function waitToRemoveFile(tempDir: string) {
 
 function generateAttachConfig(): AttachConfiguration {
 	return {
-		type: 'rdbg',
-		name: '',
-		request: 'attach',
+		type: "rdbg",
+		name: "",
+		request: "attach",
 	};
 }
 
 function generateLaunchConfig(script: string): LaunchConfiguration {
 	const config: LaunchConfiguration = {
-		type: 'rdbg',
-		name: '',
-		request: 'launch',
+		type: "rdbg",
+		name: "",
+		request: "launch",
 		useTerminal: true,
 		script,
 		waitLaunchTime: 10000,
 	};
-	if (process.platform === 'darwin' && process.env.RUBY_DEBUG_TEST_PATH) {
+	if (process.platform === "darwin" && process.env.RUBY_DEBUG_TEST_PATH) {
 		config.command = process.env.RUBY_DEBUG_TEST_PATH;
 	}
 	return config;
@@ -394,23 +394,23 @@ function generateLaunchConfig(script: string): LaunchConfiguration {
 
 function generateLaunchV2Config(script: string): LaunchConfiguration {
 	const config: LaunchConfiguration = {
-		type: 'rdbg',
-		name: '',
-		request: 'launch',
+		type: "rdbg",
+		name: "",
+		request: "launch",
 		script,
 	};
-	if (process.platform === 'darwin' && process.env.RUBY_DEBUG_TEST_PATH) {
+	if (process.platform === "darwin" && process.env.RUBY_DEBUG_TEST_PATH) {
 		config.command = process.env.RUBY_DEBUG_TEST_PATH;
 	}
-	if (process.platform === 'win32') {
+	if (process.platform === "win32") {
 		config.waitLaunchTime = 10000;
 	}
 	return config;
 }
 
 interface AttachConfiguration extends vscode.DebugConfiguration {
-	type: 'rdbg';
-	request: 'attach';
+	type: "rdbg";
+	request: "attach";
 	rdbgPath?: string;
 	debugPort?: string;
 	cwd?: string;
@@ -420,8 +420,8 @@ interface AttachConfiguration extends vscode.DebugConfiguration {
 }
 
 interface LaunchConfiguration extends vscode.DebugConfiguration {
-	type: 'rdbg';
-	request: 'launch';
+	type: "rdbg";
+	request: "launch";
 
 	script: string;
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -26,6 +26,7 @@ suite('attach', () => {
 						const res: DebugProtocol.Response = {
 							seq: req.seq,
 							type: 'response',
+							// eslint-disable-next-line @typescript-eslint/naming-convention
 							request_seq: req.seq,
 							success: true,
 							command: req.command,
@@ -132,6 +133,7 @@ suite('attach', () => {
 						const res: DebugProtocol.Response = {
 							seq: req.seq,
 							type: 'response',
+							// eslint-disable-next-line @typescript-eslint/naming-convention
 							request_seq: req.seq,
 							success: true,
 							command: req.command,

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,20 +1,20 @@
-import * as path from 'path';
-import * as Mocha from 'mocha';
-import * as glob from 'glob';
+import * as path from "path";
+import * as Mocha from "mocha";
+import * as glob from "glob";
 
 export function run(): Promise<void> {
 	// Create the mocha test
 	const mocha = new Mocha({
-		ui: 'tdd',
+		ui: "tdd",
 		color: true
 	});
 
-	mocha.timeout('20000');
+	mocha.timeout("20000");
 
-	const testsRoot = path.resolve(__dirname, '..');
+	const testsRoot = path.resolve(__dirname, "..");
 
 	return new Promise((c, e) => {
-		glob('**/**.test.js', { cwd: testsRoot }, (err, files) => {
+		glob("**/**.test.js", { cwd: testsRoot }, (err, files) => {
 			if (err) {
 				return e(err);
 			}

--- a/src/ui-test/suite/debug-test.ts
+++ b/src/ui-test/suite/debug-test.ts
@@ -34,7 +34,7 @@ describe('breakpoint', () => {
 				await bar.waitForBreakPoint();
 				await assertLocation(expected, view);
 				await bar.stop();
-				return new Promise((resolve, reject) => resolve());
+				return new Promise((resolve, _reject) => resolve());
 			});
 
 			it('debug console', async () => {
@@ -52,7 +52,7 @@ describe('breakpoint', () => {
 				await bar.waitForBreakPoint();
 				await assertLocation(3, view);
 				await bar.stop();
-				return new Promise((resolve, reject) => resolve());
+				return new Promise((resolve, _reject) => resolve());
 			});
 		});
 
@@ -78,7 +78,7 @@ describe('breakpoint', () => {
 				await bar.waitForBreakPoint();
 				await assertLocation(4, view);
 				await bar.stop();
-				return new Promise((resolve, reject) => resolve());
+				return new Promise((resolve, _reject) => resolve());
 			});
 
 			it('debug console', async () => {
@@ -99,7 +99,7 @@ describe('breakpoint', () => {
 				await bar.waitForBreakPoint();
 				await assertLocation(4, view);
 				await bar.stop();
-				return new Promise((resolve, reject) => resolve());
+				return new Promise((resolve, _reject) => resolve());
 			});
 		});
 	});
@@ -136,7 +136,7 @@ describe('breakpoint', () => {
 			await bar.waitForBreakPoint();
 			await assertLocation(8, view);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 
 		it('debug console', async () => {
@@ -154,7 +154,7 @@ describe('breakpoint', () => {
 			await bar.waitForBreakPoint();
 			await assertLocation(8, view);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 	});
 });
@@ -185,7 +185,7 @@ describe('step', () => {
 			await bar.stepInto();
 			await assertLocation(4, view);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 
 		it('debug console', async () => {
@@ -201,7 +201,7 @@ describe('step', () => {
 			await assertEvaluate('(rdbg:#debugger) s', ',s', debugView);
 			await assertLocation(3, view);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 	});
 });
@@ -232,7 +232,7 @@ describe('next', () => {
 			await bar.stepOver();
 			await assertLocation(4, view);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 
 		it('debug console', async () => {
@@ -249,7 +249,7 @@ describe('next', () => {
 			await view.click();
 			await assertLocation(3, view);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 	});
 });
@@ -282,7 +282,7 @@ describe('eval', () => {
 			await assertLocation(3, view);
 			await assertEvaluate('2', 'b', debugView);
 			await bar.stop();
-			return new Promise((resolve, reject) => resolve());
+			return new Promise((resolve, _reject) => resolve());
 		});
 	});
 });
@@ -307,7 +307,7 @@ describe('binding.break', () => {
 		await bar.continue();
 		await assertLocation(8, view);
 		await bar.stop();
-		return new Promise((resolve, reject) => resolve());
+		return new Promise((resolve, _reject) => resolve());
 	});
 });
 

--- a/src/ui-test/suite/debug-test.ts
+++ b/src/ui-test/suite/debug-test.ts
@@ -1,30 +1,30 @@
-import * as assert from 'assert';
+import * as assert from "assert";
 
-import { ActivityBar, DebugToolbar, DebugView, DefaultTreeSection, EditorView, TextEditor, TitleBar, VSBrowser, Workbench, BottomBarPanel, DebugConsoleView, SideBarView } from 'vscode-extension-tester';
+import { ActivityBar, DebugToolbar, DebugView, DefaultTreeSection, EditorView, TextEditor, TitleBar, VSBrowser, Workbench, BottomBarPanel, DebugConsoleView, SideBarView } from "vscode-extension-tester";
 
-import * as path from 'path';
+import * as path from "path";
 
 const timeoutSec = 60000;
-const projectRoot = path.join(__dirname, '..', '..', '..');
-const simpleProgramPath = path.join(projectRoot, 'src', 'ui-test', 'testdata', 'simpleProgram');
-const importAnotherFilePath = path.join(projectRoot, 'src', 'ui-test', 'testdata', 'importAnotherFile');
-const bindingBreakPath = path.join(projectRoot, 'src', 'ui-test', 'testdata', 'bindingBreak');
+const projectRoot = path.join(__dirname, "..", "..", "..");
+const simpleProgramPath = path.join(projectRoot, "src", "ui-test", "testdata", "simpleProgram");
+const importAnotherFilePath = path.join(projectRoot, "src", "ui-test", "testdata", "importAnotherFile");
+const bindingBreakPath = path.join(projectRoot, "src", "ui-test", "testdata", "bindingBreak");
 
-describe('breakpoint', () => {
-	describe('simpleProgram', () => {
+describe("breakpoint", () => {
+	describe("simpleProgram", () => {
 		beforeEach(async function () {
 			this.timeout(timeoutSec);
 
-			await openSampleProgram(simpleProgramPath, 'simpleProgram', 'test.rb');
+			await openSampleProgram(simpleProgramPath, "simpleProgram", "test.rb");
 		});
 
 		afterEach(async () => {
 			await cleanup();
 		});
 
-		describe('set breakpoint', () => {
-			it('editor', async () => {
-				const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		describe("set breakpoint", () => {
+			it("editor", async () => {
+				const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 				const expected = 2;
 				const result = await editor.toggleBreakpoint(expected);
 				assert.ok(result);
@@ -37,8 +37,8 @@ describe('breakpoint', () => {
 				return new Promise((resolve, _reject) => resolve());
 			});
 
-			it('debug console', async () => {
-				const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+			it("debug console", async () => {
+				const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 				const result = await editor.toggleBreakpoint(2);
 				assert.ok(result);
 				const view = await getDebugView();
@@ -47,8 +47,8 @@ describe('breakpoint', () => {
 				await bar.waitForBreakPoint();
 				await assertLocation(2, view);
 				const debugView = await new BottomBarPanel().openDebugConsoleView();
-				await assertEvaluate('(rdbg:#debugger) b 3', ',b 3', debugView);
-				await assertEvaluate('(rdbg:#debugger) c', ',c', debugView);
+				await assertEvaluate("(rdbg:#debugger) b 3", ",b 3", debugView);
+				await assertEvaluate("(rdbg:#debugger) c", ",c", debugView);
 				await bar.waitForBreakPoint();
 				await assertLocation(3, view);
 				await bar.stop();
@@ -56,9 +56,9 @@ describe('breakpoint', () => {
 			});
 		});
 
-		describe('remove breakpoint', () => {
-			it('editor', async () => {
-				const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		describe("remove breakpoint", () => {
+			it("editor", async () => {
+				const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 				const expected = 2;
 				const result1 = await editor.toggleBreakpoint(expected);
 				assert.ok(result1);
@@ -81,8 +81,8 @@ describe('breakpoint', () => {
 				return new Promise((resolve, _reject) => resolve());
 			});
 
-			it('debug console', async () => {
-				const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+			it("debug console", async () => {
+				const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 				const expected = 2;
 				const result = await editor.toggleBreakpoint(expected);
 				assert.ok(result);
@@ -92,10 +92,10 @@ describe('breakpoint', () => {
 				await bar.waitForBreakPoint();
 				await assertLocation(expected, view);
 				const debugView = await new BottomBarPanel().openDebugConsoleView();
-				await assertEvaluate('(rdbg:#debugger) b 3', ',b 3', debugView);
-				await assertEvaluate('(rdbg:#debugger) b 4', ',b 4', debugView);
-				await assertEvaluate('deleted: #1', ',del 1', debugView);
-				await assertEvaluate('(rdbg:#debugger) c', ',c', debugView);
+				await assertEvaluate("(rdbg:#debugger) b 3", ",b 3", debugView);
+				await assertEvaluate("(rdbg:#debugger) b 4", ",b 4", debugView);
+				await assertEvaluate("deleted: #1", ",del 1", debugView);
+				await assertEvaluate("(rdbg:#debugger) c", ",c", debugView);
 				await bar.waitForBreakPoint();
 				await assertLocation(4, view);
 				await bar.stop();
@@ -104,19 +104,19 @@ describe('breakpoint', () => {
 		});
 	});
 
-	describe('importAnotherFile', () => {
+	describe("importAnotherFile", () => {
 		beforeEach(async function () {
 			this.timeout(timeoutSec);
 
-			await openSampleProgram(importAnotherFilePath, 'importAnotherFile', 'bar.rb');
+			await openSampleProgram(importAnotherFilePath, "importAnotherFile", "bar.rb");
 		});
 
 		afterEach(async () => {
 			await cleanup();
 		});
 
-		it('debug tool bar', async () => {
-			const barFileTab = (await new EditorView().openEditor('bar.rb')) as TextEditor;
+		it("debug tool bar", async () => {
+			const barFileTab = (await new EditorView().openEditor("bar.rb")) as TextEditor;
 			const result = await barFileTab.toggleBreakpoint(2);
 			assert.ok(result);
 			const view = await getDebugView();
@@ -124,7 +124,7 @@ describe('breakpoint', () => {
 			const bar = await DebugToolbar.create(timeoutSec);
 			await bar.waitForBreakPoint();
 			await assertLocation(2, view);
-			await openFile('importAnotherFile', 'foo.rb');
+			await openFile("importAnotherFile", "foo.rb");
 			// Since the following error ocuurs when using openEditor('foo.rb'), getTabByTitle is used here:
 			// ```
 			// 	ElementClickInterceptedError: element click intercepted: Element <div draggable="true"...
@@ -139,8 +139,8 @@ describe('breakpoint', () => {
 			return new Promise((resolve, _reject) => resolve());
 		});
 
-		it('debug console', async () => {
-			const barFileTab = (await new EditorView().openEditor('bar.rb')) as TextEditor;
+		it("debug console", async () => {
+			const barFileTab = (await new EditorView().openEditor("bar.rb")) as TextEditor;
 			const result = await barFileTab.toggleBreakpoint(2);
 			assert.ok(result);
 			const view = await getDebugView();
@@ -149,8 +149,8 @@ describe('breakpoint', () => {
 			await bar.waitForBreakPoint();
 			await assertLocation(2, view);
 			const debugView = await new BottomBarPanel().openDebugConsoleView();
-			await assertEvaluate('BP - Line', ',b foo.rb:8', debugView);
-			await assertEvaluate('(rdbg:#debugger) c', ',c', debugView);
+			await assertEvaluate("BP - Line", ",b foo.rb:8", debugView);
+			await assertEvaluate("(rdbg:#debugger) c", ",c", debugView);
 			await bar.waitForBreakPoint();
 			await assertLocation(8, view);
 			await bar.stop();
@@ -159,20 +159,20 @@ describe('breakpoint', () => {
 	});
 });
 
-describe('step', () => {
-	describe('simpleProgram', () => {
+describe("step", () => {
+	describe("simpleProgram", () => {
 		beforeEach(async function () {
 			this.timeout(timeoutSec);
 
-			await openSampleProgram(simpleProgramPath, 'simpleProgram', 'test.rb');
+			await openSampleProgram(simpleProgramPath, "simpleProgram", "test.rb");
 		});
 
 		afterEach(async () => {
 			await cleanup();
 		});
 
-		it('debug tool bar', async () => {
-			const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		it("debug tool bar", async () => {
+			const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 			const result = await editor.toggleBreakpoint(2);
 			assert.ok(result);
 			const view = await getDebugView();
@@ -188,8 +188,8 @@ describe('step', () => {
 			return new Promise((resolve, _reject) => resolve());
 		});
 
-		it('debug console', async () => {
-			const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		it("debug console", async () => {
+			const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 			const result = await editor.toggleBreakpoint(2);
 			assert.ok(result);
 			const view = await getDebugView();
@@ -198,7 +198,7 @@ describe('step', () => {
 			await bar.waitForBreakPoint();
 			await assertLocation(2, view);
 			const debugView = await new BottomBarPanel().openDebugConsoleView();
-			await assertEvaluate('(rdbg:#debugger) s', ',s', debugView);
+			await assertEvaluate("(rdbg:#debugger) s", ",s", debugView);
 			await assertLocation(3, view);
 			await bar.stop();
 			return new Promise((resolve, _reject) => resolve());
@@ -206,20 +206,20 @@ describe('step', () => {
 	});
 });
 
-describe('next', () => {
-	describe('simpleProgram', () => {
+describe("next", () => {
+	describe("simpleProgram", () => {
 		beforeEach(async function () {
 			this.timeout(timeoutSec);
 
-			await openSampleProgram(simpleProgramPath, 'simpleProgram', 'test.rb');
+			await openSampleProgram(simpleProgramPath, "simpleProgram", "test.rb");
 		});
 
 		afterEach(async () => {
 			await cleanup();
 		});
 
-		it('debug tool bar', async () => {
-			const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		it("debug tool bar", async () => {
+			const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 			const view = await getDebugView();
 			const result = await editor.toggleBreakpoint(2);
 			assert.ok(result);
@@ -235,8 +235,8 @@ describe('next', () => {
 			return new Promise((resolve, _reject) => resolve());
 		});
 
-		it('debug console', async () => {
-			const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		it("debug console", async () => {
+			const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 			const result = await editor.toggleBreakpoint(2);
 			assert.ok(result);
 			const view = await getDebugView();
@@ -245,7 +245,7 @@ describe('next', () => {
 			await bar.waitForBreakPoint();
 			await assertLocation(2, view);
 			const debugView = await new BottomBarPanel().openDebugConsoleView();
-			await assertEvaluate('(rdbg:#debugger) n', ',n', debugView);
+			await assertEvaluate("(rdbg:#debugger) n", ",n", debugView);
 			await view.click();
 			await assertLocation(3, view);
 			await bar.stop();
@@ -254,20 +254,20 @@ describe('next', () => {
 	});
 });
 
-describe('eval', () => {
-	describe('simpleProgram', () => {
+describe("eval", () => {
+	describe("simpleProgram", () => {
 		beforeEach(async function () {
 			this.timeout(timeoutSec);
 
-			await openSampleProgram(simpleProgramPath, 'simpleProgram', 'test.rb');
+			await openSampleProgram(simpleProgramPath, "simpleProgram", "test.rb");
 		});
 
 		afterEach(async () => {
 			await cleanup();
 		});
 
-		it('debug console', async () => {
-			const editor = (await new EditorView().openEditor('test.rb')) as TextEditor;
+		it("debug console", async () => {
+			const editor = (await new EditorView().openEditor("test.rb")) as TextEditor;
 			const result = await editor.toggleBreakpoint(2);
 			assert.ok(result);
 			const view = await getDebugView();
@@ -276,29 +276,29 @@ describe('eval', () => {
 			await bar.waitForBreakPoint();
 			await assertLocation(2, view);
 			const debugView = await new BottomBarPanel().openDebugConsoleView();
-			await assertEvaluate('1', 'a', debugView);
-			await assertEvaluate('nil', 'b', debugView);
+			await assertEvaluate("1", "a", debugView);
+			await assertEvaluate("nil", "b", debugView);
 			await bar.stepOver();
 			await assertLocation(3, view);
-			await assertEvaluate('2', 'b', debugView);
+			await assertEvaluate("2", "b", debugView);
 			await bar.stop();
 			return new Promise((resolve, _reject) => resolve());
 		});
 	});
 });
 
-describe('binding.break', () => {
+describe("binding.break", () => {
 	beforeEach(async function () {
 		this.timeout(timeoutSec);
 
-		await openSampleProgram(bindingBreakPath, 'bindingBreak', 'test.rb');
+		await openSampleProgram(bindingBreakPath, "bindingBreak", "test.rb");
 	});
 
 	afterEach(async () => {
 		await cleanup();
 	});
 
-	it('debug tool bar', async () => {
+	it("debug tool bar", async () => {
 		const view = await getDebugView();
 		await view.start();
 		const bar = await DebugToolbar.create(timeoutSec);
@@ -312,7 +312,7 @@ describe('binding.break', () => {
 });
 
 async function assertLocation(expected: number, view: DebugView) {
-	const tree = await view.getContent().getSection('Call Stack') as DefaultTreeSection;
+	const tree = await view.getContent().getSection("Call Stack") as DefaultTreeSection;
 	const items = await tree.getVisibleItems();
 	if (items.length === 0) {
 		assert.fail("Call Stack Section is not visible");
@@ -327,7 +327,7 @@ async function assertLocation(expected: number, view: DebugView) {
 }
 
 async function getDebugView(): Promise<DebugView> {
-	const control = await new ActivityBar().getViewControl('Run');
+	const control = await new ActivityBar().getViewControl("Run");
 	if (control === undefined) {
 		assert.fail("Can't find a View for debug");
 	}
@@ -341,7 +341,7 @@ async function openSampleProgram(path: string, sectionTitle: string, targetFileN
 }
 
 async function openFile(sectionTitle: string, targetFileName: string) {
-	(await new ActivityBar().getViewControl('Explorer'))?.openView();
+	(await new ActivityBar().getViewControl("Explorer"))?.openView();
 
 	const view = new SideBarView();
 	const tree = (await view.getContent().getSection(sectionTitle)) as DefaultTreeSection;
@@ -362,10 +362,10 @@ async function assertEvaluate(expected: string, expression: string, view: DebugC
 
 async function cleanup() {
 	await VSBrowser.instance.waitForWorkbench();
-	await new Workbench().executeCommand('Remove All Breakpoints');
+	await new Workbench().executeCommand("Remove All Breakpoints");
 	await new Promise(res => setTimeout(res, 2000));
-	await (await new ActivityBar().getViewControl('Run'))?.closeView();
-	await (await new ActivityBar().getViewControl('Explorer'))?.closeView();
-	await new TitleBar().select('File', 'Close Folder');
+	await (await new ActivityBar().getViewControl("Run"))?.closeView();
+	await (await new ActivityBar().getViewControl("Explorer"))?.closeView();
+	await new TitleBar().select("File", "Close Folder");
 	await new EditorView().closeAllEditors();
 }


### PR DESCRIPTION
Currently, many common ESLint rules are not enabled for RDBG. This results in inconsistencies in the code base and sometimes possible issues. This PR suggests turning on a few rules that I think greatly improve the consistency across the entire codebase.

Note: each rule was enabled in a different commit, to make it easier to review. All corrections were automated, the only manual changes in this PR are adding the format script to `package.json` and configuring the ESLint rules.

The commits
- Add a format script to easily run automated fixes
- Add consistent naming rule. We have a mix of snakecase and camelcase for variables and functions. Maintaining consistency improves readibility
- Add `no-unused-vars`. This actually caught a few unused variables in the codebase. You can "escape" this rule by leading the name of the variable with an underscore (e.g.: `_myVar`)
- Add `eqeqeq`. Not using triple equals mean that implicit type conversions will occur, which are prone to cause errors
- Add `quotes` with `double` style. There was a mix of single and double quotes, that will standardize everything in the same style
- Add `prefer-const`. If a variable is not mutate, it is better to prefer `const` instead of using `let`