### PR TITLE
Fix error in auto merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
         if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         run : |
           gh pr review --approve "$PR_URL"
-          gh pr merge --auto --merge "$PR_URL"
+          gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Only squash and rebase can be used in vscode-rdbg repository.

```
Message: Merge commits are not allowed on this repository., Locations: [{Line:1 Column:58}]
```