### PR TITLE
Match versions @types/vscode and engines.vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@types/glob": "^8.1.0",
 				"@types/mocha": "^10.0.1",
 				"@types/node": "^18.15.3",
-				"@types/vscode": "^1.76.0",
+				"@types/vscode": "^1.65.0",
 				"@typescript-eslint/eslint-plugin": "^5.55.0",
 				"@typescript-eslint/parser": "^5.55.0",
 				"@vscode/debugprotocol": "^1.59.0",
@@ -24,7 +24,7 @@
 				"vscode-extension-tester": "^5.5.1"
 			},
 			"engines": {
-				"vscode": "^1.49.0"
+				"vscode": "^1.65.0"
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"rdbg"
 	],
 	"engines": {
-		"vscode": "^1.49.0"
+		"vscode": "^1.65.0"
 	},
 	"activationEvents": [
 		"onLanguage:ruby",
@@ -336,7 +336,7 @@
 		"@types/glob": "^8.1.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^18.15.3",
-		"@types/vscode": "^1.76.0",
+		"@types/vscode": "^1.65.0",
 		"@typescript-eslint/eslint-plugin": "^5.55.0",
 		"@typescript-eslint/parser": "^5.55.0",
 		"@vscode/debugprotocol": "^1.59.0",


### PR DESCRIPTION
The reason of setting 1.65.0 is to use InlayHintsProvider. FYI: https://code.visualstudio.com/updates/v1_65%5C\#_inlay-hints