### PR TITLE
Rename "rdbg.trace.toggleTrace" to "rdbg.trace.toggle"

### DIFF
--- a/src/rdbgTreeItem.ts
+++ b/src/rdbgTreeItem.ts
@@ -87,7 +87,7 @@ export class ToggleTreeItem extends RdbgTreeItem {
 		kind: string
 	){
 		super(label, {
-			command: { command: kind + ".toggleTrace" },
+			command: { command: kind + ".toggle" },
 			collapsibleState: vscode.TreeItemCollapsibleState.None,
 			iconPath: playCircleIcon
 		});

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -73,7 +73,7 @@ export function registerTraceProvider(ctx: vscode.ExtensionContext, emitter: vsc
 			treeProvider.loadMoreTraceLogs(threadId);
 		}),
 
-		vscode.commands.registerCommand("rdbg.trace.toggleTrace", async () => {
+		vscode.commands.registerCommand("rdbg.trace.toggle", async () => {
 			const item = treeProvider.toggleTreeItem;
 			if (item === undefined) {
 				return;


### PR DESCRIPTION
Part of ruby/vscode-rdbg#174

To use this toggle command in RdbgRecordInspector, the command name is changed