### PR TITLE
Wait for clearing the console of all text

### DIFF
--- a/src/ui-test/suite/debug-test.ts
+++ b/src/ui-test/suite/debug-test.ts
@@ -358,6 +358,7 @@ async function assertEvaluate(expected: string, expression: string, view: DebugC
 	const text = await view.getText();
 	assert.ok(text.includes(expected), `Expected to include ${expected} in ${text}, but not.`);
 	await view.clearText();
+	await view.wait(timeoutSec);
 }
 
 async function cleanup() {


### PR DESCRIPTION
ElementClickInterceptedError is sometimes occurred in test. This error occurred when "context-view-block" element is clicked. "context-view-block" element seems to be created to prevent users from clicking on a view in the middle of rendering. One possible cause of ElementClickInterceptedError is that the view in the middle of rendering is clicked after clearing the console of all text.