### PR TITLE
Send a custom request for collecting logs only when toggle button is enabled

### DIFF
--- a/src/rdbgTreeItem.ts
+++ b/src/rdbgTreeItem.ts
@@ -93,6 +93,10 @@ export class ToggleTreeItem extends RdbgTreeItem {
 		});
 	}
 
+	get enabled(): boolean {
+    return this._enabled
+  }
+
 	async toggle() {
 		const session = vscode.debug.activeDebugSession;
 		if (session === undefined) {

--- a/src/record.ts
+++ b/src/record.ts
@@ -35,7 +35,9 @@ export function registerRecordProvider(emitter: vscode.EventEmitter<number | und
 
   disposables.push(
     emitter.event((threadId) => {
-      treeProvider.updateRecordLogs(threadId);
+      if (treeProvider.toggleTreeItem?.enabled) {
+				treeProvider.updateRecordLogs(threadId);
+			}
     }),
 
     vscode.debug.onDidTerminateDebugSession(async () => {

--- a/src/trace.ts
+++ b/src/trace.ts
@@ -39,7 +39,9 @@ export function registerTraceProvider(ctx: vscode.ExtensionContext, emitter: vsc
 		),
 
 		emitter.event((threadId) => {
-			treeProvider.updateTraceLogs(threadId);
+			if (treeProvider.toggleTreeItem?.enabled) {
+				treeProvider.updateTraceLogs(threadId);
+			}
 		}),
 
 		vscode.debug.onDidTerminateDebugSession(async () => {


### PR DESCRIPTION
Currently, rdbgRecordInspector and rdbgTraceInspector send a custom request for collecting logs when stopped event is received. We do not have to send the request when the Inspectors are not enabled