### PR TITLE
Disable trace inspector when the debug.gem is less than 1.8.0 correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -242,8 +242,7 @@
 			"debug": [
 				{
 					"id": "rdbg.inspector",
-					"name": "Trace Inspector",
-					"when": "traceInspectorEnabled == true"
+					"name": "Trace Inspector"
 				}
 			]
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -303,6 +303,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory, Ver
 			watcher.onDidDelete(() => this.activateRuby(cwd));
 		}
 
+		vscode.commands.executeCommand("rdbg.inspector.startDebugSession", session);
 		if (c.request === "attach") {
 			return this.attach(session);
 		}

--- a/src/rdbgTreeItem.ts
+++ b/src/rdbgTreeItem.ts
@@ -239,10 +239,14 @@ export class ToggleTreeItem extends RdbgTreeItem {
 		await customRequest(session, "rdbgTraceInspector", args);
 	}
 
-	async disable() {
+	async resetView() {
 		this._enabled = false;
 		this.iconPath = playCircleIcon;
 		this.label = "Enable Trace";
+	}
+
+	async disable() {
+		this.resetView();
 		const session = vscode.debug.activeDebugSession;
 		if (session === undefined || this._enabledCommand === undefined) {
 			return;


### PR DESCRIPTION
Currently, trace inspector has the following problems

Users receive error messages every time debug session is activated when the debug.gem is less than 1.8.0. This is annoying

Although users receive error messages, traceInspector commands are sent to the debug.gem, and debug.gem will crash.

This PR fixes it