### PR TITLE
Publish all DAP messages to event emitter

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -190,9 +190,7 @@ class RdbgDebugAdapterTrackerFactory implements vscode.DebugAdapterTrackerFactor
 	}
 
 	private publishMessage(message: any) {
-		if (message.event === "stopped" || message.command === "launch") {
-			this._emitter.fire(message);
-		}
+		this._emitter.fire(message);
 	}
 }
 


### PR DESCRIPTION
We can enable trace inspector before starting debugging in attaching mode.