### PR TITLE
Do not update @types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "@types/vscode"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@types/glob": "^8.1.0",
 				"@types/mocha": "^10.0.1",
 				"@types/node": "^20.2.5",
-				"@types/vscode": "^1.78.0",
+				"@types/vscode": "^1.65.0",
 				"@typescript-eslint/eslint-plugin": "^5.59.7",
 				"@typescript-eslint/parser": "^5.59.7",
 				"@vscode/debugprotocol": "^1.59.0",

--- a/package.json
+++ b/package.json
@@ -390,7 +390,7 @@
 		"@types/glob": "^8.1.0",
 		"@types/mocha": "^10.0.1",
 		"@types/node": "^20.2.5",
-		"@types/vscode": "^1.78.0",
+		"@types/vscode": "^1.65.0",
 		"@typescript-eslint/eslint-plugin": "^5.59.7",
 		"@typescript-eslint/parser": "^5.59.7",
 		"@vscode/debugprotocol": "^1.59.0",


### PR DESCRIPTION
We need to match the versions @types/vscode and engines.vscode to publish the extension correctly