### PR TITLE
Output an error when failing to run tests

### DIFF
--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -15,7 +15,7 @@ async function main() {
 		// Download VS Code, unzip it and run the integration test
 		await runTests({ extensionDevelopmentPath, extensionTestsPath });
 	} catch (err) {
-		console.error("Failed to run tests");
+		console.error("Failed to run tests:", err);
 		process.exit(1);
 	}
 }


### PR DESCRIPTION
Sometimes, an error is occurred such as https://github.com/ruby/vscode-rdbg/actions/runs/5041089141/jobs/9040458302\?pr\=265\#step:9:48. We need to know what is happening.