### PR TITLE
Use npm ci when installing packages on CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         gem install debug
         rdbg -v
-    - run: npm install
+    - run: npm ci
     - run: xvfb-run -a npm test
       if: runner.os == 'Linux'
     # VS code overrides The PATH environment variable:


### PR DESCRIPTION
`npm ci` is helpful when installing packages on CI. If we use `npm install`, pacakge-lock.json may be overridden, but `npm ci` do not. We can always run tests in the same environment.  Also, if package-lock.json does not match package.json, `npm ci` will exit with an error. Thus, we can avoid forgetting to update the lock file.

See https://docs.npmjs.com/cli/v9/commands/npm-ci

Acknowledgment

Inspired by https://github.com/ruby/vscode-typeprof/pull/103#discussion_r1199728216.