### PR TITLE
Add the ability to hide the #class item for each object

### DIFF
--- a/package.json
+++ b/package.json
@@ -234,6 +234,11 @@
 						"none"
 					],
 					"default": "none"
+				},
+				"rdbg.hideClassItem": {
+					"type": "boolean",
+					"default": false,
+					"description": "Hide the #class item for each object in VARIABLES view"
 				}
 			}
 		},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -205,6 +205,11 @@ class RdbgInitialConfigurationProvider implements vscode.DebugConfigurationProvi
 		config.rdbgExtensions = extensions;
 		config.rdbgInitialScripts = []; // for future extension
 
+		const hideClassItem = vscode.workspace.getConfiguration("rdbg").get<boolean>("hideClassItem");
+		if (hideClassItem) {
+			config.hideClassItem = true;
+		}
+
 		if (config.script || config.request === "attach") {
 			return config;
 		}


### PR DESCRIPTION
Closes ruby/vscode-rdbg#37

We can hide the #class item for each object by setting true in the field hideClassItem in User Settings

## Before
<img width="357" alt="Screen Shot 2023-06-03 at 13 34 01" src="https://github.com/ruby/vscode-rdbg/assets/59436572/9a386556-b1c4-4117-8d19-6c94850cf46a">


## After

<img width="357" alt="Screen Shot 2023-06-03 at 13 33 26" src="https://github.com/ruby/vscode-rdbg/assets/59436572/7a6c571f-495d-43a3-b98a-9b8d28b86bd1">
