### PR TITLE
Support a relative path in the socket path

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,7 +22,7 @@ import {
 import { DebugProtocol } from "@vscode/debugprotocol";
 import { registerInspectorView } from "./inspector";
 import { AttachConfiguration, LaunchConfiguration } from "./config";
-import { VersionChecker } from "./utils";
+import { VersionChecker, fullPath } from "./utils";
 
 const asyncExec = promisify(child_process.exec);
 
@@ -483,7 +483,7 @@ class RdbgAdapterDescriptorFactory implements DebugAdapterDescriptorFactory, Ver
 		}
 
 		if (sockPath) {
-			return new DebugAdapterNamedPipeServer(sockPath);
+			return new DebugAdapterNamedPipeServer(fullPath(sockPath, session));
 		}
 		else if (port) {
 			return new vscode.DebugAdapterServer(port, host);

--- a/src/rdbgTreeItem.ts
+++ b/src/rdbgTreeItem.ts
@@ -10,9 +10,7 @@ import {
 	RdbgInspectorCommand,
 	BaseLog,
 } from "./protocol";
-import { customRequest } from "./utils";
-import * as path from "path";
-import * as fs from "fs";
+import { customRequest, fullPath } from "./utils";
 
 export type RdbgTreeItemOptions = Pick<
 	vscode.TreeItem,
@@ -112,7 +110,7 @@ export class RecordLogItem extends BaseLogItem {
 		state?: vscode.TreeItemCollapsibleState,
 	)
 	{
-        log.location.path = fullPath(log.location.path);
+		log.location.path = fullPath(log.location.path, vscode.debug.activeDebugSession);
 		const description = prettyPath(log.location.path) + ":" + log.location.line;
 		const opts: RdbgTreeItemOptions = { collapsibleState: state };
 		opts.collapsibleState = state;
@@ -150,7 +148,7 @@ const locationIcon = new vscode.ThemeIcon("location");
 
 export class LineTraceLogItem extends TraceLogItem {
 	constructor(log: TraceLog, idx: number, state?: vscode.TreeItemCollapsibleState) {
-        log.location.path = fullPath(log.location.path);
+		log.location.path = fullPath(log.location.path, vscode.debug.activeDebugSession);
 		const label = prettyPath(log.location.path) + ":" + log.location.line.toString();
 		const tooltip = log.location.path;
 		const opts: RdbgTreeItemOptions = { iconPath: locationIcon, collapsibleState: state , tooltip};
@@ -164,7 +162,7 @@ export class CallTraceLogItem extends TraceLogItem {
 	public readonly returnValue: TraceLog["returnValue"];
 	public readonly parameters: TraceLog["parameters"];
 	constructor(log: TraceLog, idx: number, state?: vscode.TreeItemCollapsibleState) {
-        log.location.path = fullPath(log.location.path);
+		log.location.path = fullPath(log.location.path, vscode.debug.activeDebugSession);
 		let iconPath: vscode.ThemeIcon;
 		if (log.returnValue) {
 			iconPath = arrowCircleLeft;
@@ -276,19 +274,4 @@ export class ToggleTreeItem extends RdbgTreeItem {
 		await customRequest(session, "rdbgTraceInspector", args);
 		this._enabledCommand = undefined;
 	}
-}
-
-function fullPath(p: string) {
-    if (path.isAbsolute(p)) {
-        return p;
-    }
-    const workspace = vscode.debug.activeDebugSession?.workspaceFolder;
-    if (workspace === undefined) {
-        return p;
-    }
-    const fullPath = path.join(workspace.uri.fsPath, p);
-    if (fs.existsSync(fullPath)) {
-        return fullPath;
-    }
-    return p;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
 import * as vscode from "vscode";
 import { LaunchConfiguration } from "./config";
+import * as path from "path";
+import * as fs from "fs";
 
 export async function customRequest(session: vscode.DebugSession, command: string, args?: any) {
 	try {
@@ -13,4 +15,19 @@ export async function customRequest(session: vscode.DebugSession, command: strin
 export interface VersionChecker {
     getVersion(config: LaunchConfiguration): Promise<string | null>;
     vernum(version: string): number;
+}
+
+export function fullPath(p: string, session: vscode.DebugSession | undefined) {
+    if (path.isAbsolute(p)) {
+        return p;
+    }
+    const workspace = session?.workspaceFolder;
+    if (workspace === undefined) {
+        return p;
+    }
+    const fullPath = path.join(workspace.uri.fsPath, p);
+    if (fs.existsSync(fullPath)) {
+        return fullPath;
+    }
+    return p;
 }


### PR DESCRIPTION
Closes ruby/vscode-rdbg#258

We only support a relative path from a workspace directory.