### PR TITLE
Use object instead of string for env

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
 								"description": "Specify pairs of remote root path and local root path like `/remote_dir:/local_dir`. `/remote_dir:$(workspaceFolder)` is useful. You can specify multiple pairs like `/rem1:/loc1,/rem2:/loc2` by concatenating with `,`."
 							},
 							"env": {
-								"type": "string",
+								"type": "object",
 								"description": "Additional environment variables to pass to the rdbg process",
 								"default": {}
 							}


### PR DESCRIPTION
VSCode was complaining when I tried to pass `env` variables

![Screenshot 2023-10-16 at 18 00 01](https://github.com/ruby/vscode-rdbg/assets/781254/4bdf1d9d-1327-4b06-b362-ed4e27cb33f4)
