### PR TITLE
Allow to attach to multiple sockets

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ You can specify the following "attach" configurations.
   * Specify pairs of remote root path and local root path like `/remote_dir:/local_dir` if sharing the same source repository with local and remote computers.
   * You can specify multiple pairs like `/rem1:/loc1,/rem2:/loc2` by concatenating with `,`.
   * default: undefined
+* `supportAttachMultiSockets`
+  * Allow for attaching multiple running sockets at once 
 
 Without `debugPort` configuration, the
 

--- a/package.json
+++ b/package.json
@@ -83,6 +83,11 @@
 								"type": "string",
 								"description": "Specify pairs of remote root path and local root path like `/remote_dir:/local_dir`. `/remote_dir:$(workspaceFolder)` is useful. You can specify multiple pairs like `/rem1:/loc1,/rem2:/loc2` by concatenating with `,`."
 							},
+							"supportAttachMultiSockets": {
+								"type": "boolean",
+								"description": "Allow for attaching multiple running sockets at once",
+								"default": false
+							},
 							"env": {
 								"type": "object",
 								"description": "Additional environment variables to pass to the rdbg process",

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,7 @@ export interface AttachConfiguration extends DebugConfiguration {
 	debugPort?: string;
 	cwd?: string;
 	showProtocolLog?: boolean;
+	supportAttachMultiSockets?: boolean;
 
 	autoAttach?: string;
 }
@@ -32,5 +33,5 @@ export interface LaunchConfiguration extends DebugConfiguration {
 	rdbgPath?: string;
 	showProtocolLog?: boolean;
 
-	useTerminal?: boolean
+	useTerminal?: boolean;
 }


### PR DESCRIPTION
For https://github.com/ruby/vscode-rdbg/issues/372

- Introduce a new adapter `MultiSessionDebugAdapter` where it emits events with all socket paths
- Add a listener that subscribes to custom events that `MultiSessionDebugAdapter` emits, which attach it as a child process
- This is enabled via `supportAttachMultiSockets` config

### Screenshot

When running a rails server with 4 processes

| Before | After |
|--------|--------|
| ![Screenshot 2024-02-03 at 22 29 51](https://github.com/ruby/vscode-rdbg/assets/781254/7803f22d-e3f1-472a-b17c-c37e00be9c4d) | ![Screenshot 2024-02-03 at 22 31 41](https://github.com/ruby/vscode-rdbg/assets/781254/99524a75-b23a-4417-8bce-bd0941c9359d) |
| when set to`false`, it defaults to the picker selector  | when set to `true`, it attaches all as child processes |
