### PR TITLE
Add launchable into CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,21 @@ on:
     branches:
       - master
 
+env:
+  # The file path is inconsistent when setting a relative path in VS Code tests.
+  # As a workaround, an absolute path is configured.
+  # https://github.com/microsoft/vscode-test/issues/17
+  LAUNCHABLE_TEST_REPORTS: ${{ format('{0}-{1}', github.workspace, 'launchable-test-reports.xml') }}
+  # GITHUB_PULL_REQUEST_URL are used for commenting test reports in Launchable Github App.
+  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/link.py#L42
+  GITHUB_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+  # The following envs are necessary in Launchable tokenless authentication.
+  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L20
+  LAUNCHABLE_ORGANIZATION: "ruby"
+  LAUNCHABLE_WORKSPACE: "vscode-rdbg"
+  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L71
+  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
 jobs:
   test:
     strategy:
@@ -18,6 +33,25 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Set fetch-depth: 0 so that Launchable can receive commits information.
+        fetch-depth: 0
+    # Launchable requires Python and Java
+    # https://www.launchableinc.com/docs/resources/cli-reference/
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: '8'
+    - name: Setup Launchable
+      run: |
+        pip install launchable
+        launchable verify
+        launchable record build --name "${{ env.GITHUB_PR_HEAD_SHA }}"
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -48,6 +82,9 @@ jobs:
       if: runner.os == 'macOS'
     - run: npm test
       if: runner.os != 'Linux'
+    - name: Record tests with Launchable
+      run: launchable record tests --flavor os=${{ matrix.os }} --flavor test=integration_test file ${{ env.LAUNCHABLE_TEST_REPORTS }}
+      if: always()
 
   dependabot:
     needs: test

--- a/.github/workflows/ui-test.yaml
+++ b/.github/workflows/ui-test.yaml
@@ -5,12 +5,45 @@ on:
     # This job runs at 00:00 UTC every day.
     - cron: '0 0 * * *'
 
+env:
+  LAUNCHABLE_TEST_REPORTS: "launchable-test-reports.xml"
+  # GITHUB_PULL_REQUEST_URL are used for commenting test reports in Launchable Github App.
+  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/link.py#L42
+  GITHUB_PULL_REQUEST_URL: ${{ github.event.pull_request.html_url }}
+  # The following envs are necessary in Launchable tokenless authentication.
+  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L20
+  LAUNCHABLE_ORGANIZATION: "ruby"
+  LAUNCHABLE_WORKSPACE: "vscode-rdbg"
+  # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L71
+  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        # Set fetch-depth: 0 so that Launchable can receive commits information.
+        fetch-depth: 0
+    # Launchable requires Python and Java
+    # https://www.launchableinc.com/docs/resources/cli-reference/
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.10"
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'adopt'
+        java-version: '8'
+    - name: Setup Launchable
+      run: |
+        pip install launchable
+        launchable verify
+        : # The build name must be a unique identifier for this build. Therefore, $GITHUB_RUN_ID is appropriate in this case.
+        : # https://www.launchableinc.com/docs/sending-data-to-launchable/using-the-launchable-cli/recording-builds-with-the-launchable-cli/
+        launchable record build --name "$GITHUB_RUN_ID"
+
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -22,3 +55,6 @@ jobs:
     - run: gem install debug
     - run: npm install @types/vscode@1.65.0
     - run: xvfb-run -a npm run ui-test
+    - name: Record tests with Launchable
+      run: launchable record tests --flavor os=ubuntu-latest --flavor test=e2e_test file $LAUNCHABLE_TEST_REPORTS
+      if: always()

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
 				"eslint-config-prettier": "^9.1.0",
 				"glob": "^8.1.0",
 				"mocha": "^10.2.0",
+				"mocha-junit-reporter": "^2.2.1",
 				"prettier": "^3.2.5",
 				"typescript": "^5.3.3",
 				"vscode-extension-tester": "^7.0.0"
@@ -1192,6 +1193,15 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true,
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/cheerio": {
 			"version": "1.0.0-rc.12",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -1362,6 +1372,15 @@
 			},
 			"engines": {
 				"node": ">= 8"
+			}
+		},
+		"node_modules/crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true,
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/css-select": {
@@ -2576,6 +2595,12 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
 		"node_modules/is-docker": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -2993,6 +3018,17 @@
 				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
+		"node_modules/md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"dependencies": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
 		"node_modules/mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -3147,6 +3183,37 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/mochajs"
+			}
+		},
+		"node_modules/mocha-junit-reporter": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz",
+			"integrity": "sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==",
+			"dev": true,
+			"dependencies": {
+				"debug": "^4.3.4",
+				"md5": "^2.3.0",
+				"mkdirp": "^3.0.0",
+				"strip-ansi": "^6.0.1",
+				"xml": "^1.0.1"
+			},
+			"peerDependencies": {
+				"mocha": ">=2.2.5"
+			}
+		},
+		"node_modules/mocha-junit-reporter/node_modules/mkdirp": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+			"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+			"dev": true,
+			"bin": {
+				"mkdirp": "dist/cjs/src/bin.js"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
 		"node_modules/mocha/node_modules/glob": {
@@ -4710,6 +4777,12 @@
 				}
 			}
 		},
+		"node_modules/xml": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+			"integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+			"dev": true
+		},
 		"node_modules/xml2js": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
@@ -5646,6 +5719,12 @@
 				"supports-color": "^7.1.0"
 			}
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+			"dev": true
+		},
 		"cheerio": {
 			"version": "1.0.0-rc.12",
 			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.12.tgz",
@@ -5779,6 +5858,12 @@
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+			"dev": true
 		},
 		"css-select": {
 			"version": "5.1.0",
@@ -6665,6 +6750,12 @@
 				"binary-extensions": "^2.0.0"
 			}
 		},
+		"is-buffer": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
+		},
 		"is-docker": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
@@ -6968,6 +7059,17 @@
 				}
 			}
 		},
+		"md5": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+			"integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+			"dev": true,
+			"requires": {
+				"charenc": "0.0.2",
+				"crypt": "0.0.2",
+				"is-buffer": "~1.1.6"
+			}
+		},
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -7139,6 +7241,27 @@
 					"requires": {
 						"has-flag": "^4.0.0"
 					}
+				}
+			}
+		},
+		"mocha-junit-reporter": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/mocha-junit-reporter/-/mocha-junit-reporter-2.2.1.tgz",
+			"integrity": "sha512-iDn2tlKHn8Vh8o4nCzcUVW4q7iXp7cC4EB78N0cDHIobLymyHNwe0XG8HEHHjc3hJlXm0Vy6zcrxaIhnI2fWmw==",
+			"dev": true,
+			"requires": {
+				"debug": "^4.3.4",
+				"md5": "^2.3.0",
+				"mkdirp": "^3.0.0",
+				"strip-ansi": "^6.0.1",
+				"xml": "^1.0.1"
+			},
+			"dependencies": {
+				"mkdirp": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+					"integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+					"dev": true
 				}
 			}
 		},
@@ -8230,6 +8353,12 @@
 			"integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
 			"dev": true,
 			"requires": {}
+		},
+		"xml": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+			"integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
+			"dev": true
 		},
 		"xml2js": {
 			"version": "0.5.0",

--- a/package.json
+++ b/package.json
@@ -399,6 +399,7 @@
 		"eslint-config-prettier": "^9.1.0",
 		"glob": "^8.1.0",
 		"mocha": "^10.2.0",
+		"mocha-junit-reporter": "^2.2.1",
 		"prettier": "^3.2.5",
 		"typescript": "^5.3.3",
 		"vscode-extension-tester": "^7.0.0"

--- a/src/test/suite/index.ts
+++ b/src/test/suite/index.ts
@@ -1,13 +1,22 @@
 import * as path from "path";
 import * as Mocha from "mocha";
 import * as glob from "glob";
+import { MochaOptions } from "mocha";
 
 export function run(): Promise<void> {
-	// Create the mocha test
-	const mocha = new Mocha({
+	const mochaOpts: MochaOptions = {
 		ui: "tdd",
 		color: true
-	});
+	}
+	const testReports = process.env.LAUNCHABLE_TEST_REPORTS
+	if (testReports) {
+		mochaOpts.reporter = 'mocha-junit-reporter';
+		mochaOpts.reporterOptions = {
+			mochaFile: testReports
+		}
+	}
+	// Create the mocha test
+	const mocha = new Mocha(mochaOpts);
 
 	mocha.timeout("20000");
 

--- a/src/ui-test/config.ts
+++ b/src/ui-test/config.ts
@@ -1,7 +1,15 @@
 import { MochaOptions } from "vscode-extension-tester";
 
 const options: MochaOptions = {
-	timeout: 180000,
+    timeout: 180000,
 };
+
+const testReports = process.env.LAUNCHABLE_TEST_REPORTS;
+if (testReports) {
+    options.reporter = "mocha-junit-reporter";
+    options.reporterOptions = {
+        mochaFile: testReports,
+    };
+}
 
 module.exports = options;


### PR DESCRIPTION
@ko1 san allowed me to integrate [Launchable](https://www.launchableinc.com/) into ruby/vscode-rdbg. By introducing Launchable, we can get the following benefits: For more details in Launchable Web Console, please take a look at https://app.launchableinc.com/organizations/demo/workspaces/demo/data/test-sessions.

## Test reports in Github comments.
We can check the test results easily.

<img width="741" alt="Screenshot 2024-01-29 at 19 20 57" src="https://github.com/ruby/debug/assets/59436572/283b27d6-7b43-40bf-b423-8bb94708228c">

## Rich UI to see stderr and stdout in failed tests

<img width="741" alt="Screenshot 2024-01-29 at 19 23 08" src="https://github.com/ruby/debug/assets/59436572/68f52a50-8e96-4f7f-861d-2dc098dec39f">

## Analysis for Flakey tests

<img width="1007" alt="Screenshot 2024-01-29 at 19 24 14" src="https://github.com/ruby/debug/assets/59436572/ca9f972e-9744-40b9-92a2-353b562d340e">

