### PR TITLE
Use `github.sha` when running tests on the master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ env:
   LAUNCHABLE_ORGANIZATION: "ruby"
   LAUNCHABLE_WORKSPACE: "vscode-rdbg"
   # https://github.com/launchableinc/cli/blob/v1.80.1/launchable/utils/authentication.py#L71
-  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  GITHUB_PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   test:


### PR DESCRIPTION
Fix the error in https://github.com/ruby/vscode-rdbg/actions/runs/7839878334/job/21393619663. The reason is because `github.event.pull_request.head.sha` returns empty string when running tests on the master branch. In this case, we can use `github.sha` instead.