### PR TITLE
Only send initial evaluate request to rdbg sessions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,7 @@ export function activate(context: vscode.ExtensionContext) {
 
 	context.subscriptions.push(vscode.debug.onDidStartDebugSession(async session => {
 		const config = session.configuration;
-		if (config.request !== "launch" || config.useTerminal || config.noDebug) return;
+		if (config.type !== "rdbg" || config.request !== "launch" || config.useTerminal || config.noDebug) return;
 
 		const args: DebugProtocol.EvaluateArguments = {
 			expression: ",eval $stdout.sync=true",


### PR DESCRIPTION
Fixes #505.

I didn't test this PR as I am not a Ruby user, so someone should try this before this gets merged.

But it would be good to merge, as the underlying bug causes trouble for other extensions.